### PR TITLE
tswow: fix 'realm send' command

### DIFF
--- a/tswow-scripts/runtime/Realm.ts
+++ b/tswow-scripts/runtime/Realm.ts
@@ -280,9 +280,10 @@ export namespace Realm {
             , async(args)=>{
 
             let realms = getRealmsOrDefault(args);
-            args = args.filter(x=>realms.find(y=>y.identifier==x));
-            let cmd = args.join(' ')
-            getRealm(args[0]).sendWorldserverCommand(cmd,true);
+            let selection = args.filter(x=>realms.find(y=>y.identifier==x))[0];
+            args.shift();
+            let cmd = args.join(' ');
+            getRealm(selection).sendWorldserverCommand(cmd,true);
         });
 
         realm.addCommand(


### PR DESCRIPTION
Not sure if you accept PRs, but if so here's one to fix the 'realm send' command, which is currently setup to send the realm name as the WS command. Feel free to copy this in separately as well ^^