### PR TITLE
addon: GameTooltip should extend WoWAPI.UIObject

### DIFF
--- a/install-config/include-addon/global.d.ts
+++ b/install-config/include-addon/global.d.ts
@@ -11982,7 +11982,7 @@ declare function GetRealmName(): string;
 /// <reference path="../auction.d.ts" />
 
 declare namespace WoWAPI {
-    interface GameTooltip {
+    interface GameTooltip extends UIObject {
 
         /**
          * Adds Line to tooltip with textLeft on left side of line and textRight on right side


### PR DESCRIPTION
GameTooltip with Object extended:

```ts
frame.SetScript('OnEvent', (_, event, ...args) => {
  if ((event === 'CHAT_MSG_SAY') && (args[1] === GetUnitName('player', true))) {
    if (args[0] === 'test') {
      console.log(GameTooltip.GetName())
      console.log(GameTooltip.GetObjectType())
      console.log(GameTooltip.IsObjectType('GameTooltip') && 'true')
    }
  }
})
```
results in:

![211018072425](https://user-images.githubusercontent.com/81722954/137691481-9a46fc19-fd4c-4647-af4e-c02eeaa9820d.png)

