### PR TITLE
addon: GameTooltip should extend WoWAPI.UIObject

### DIFF
--- a/install-config/include-addon/global.d.ts
+++ b/install-config/include-addon/global.d.ts
@@ -11982,7 +11982,7 @@ declare function GetRealmName(): string;
 /// <reference path="../auction.d.ts" />
 
 declare namespace WoWAPI {
-    interface GameTooltip {
+    interface GameTooltip extends UIObject {
 
         /**
          * Adds Line to tooltip with textLeft on left side of line and textRight on right side


### PR DESCRIPTION
Not sure if it makes life easier to PR on this branch or master atm. [PR to master](https://github.com/tswow/tswow/pull/384)