### PR TITLE
Creature React States

### DIFF
--- a/tswow-core/Private/TSCreature.cpp
+++ b/tswow-core/Private/TSCreature.cpp
@@ -1154,14 +1154,14 @@ void TSCreature::AttackStart(TSUnit _target)
     creature->AI()->AttackStart(target);
 }
 
-void TSCreature::SetReactState(ReactStates state)
+void TSCreature::SetReactState(uint8 state)
 {
-    creature->SetReactState(state);
+    creature->SetReactState(static_cast<ReactStates>(state));
 }
 
-ReactStates TSCreature::GetReactState()
+uint8 TSCreature::GetReactState()
 {
-    return creature->GetReactState();
+     return static_cast<uint8>(creature->GetReactState());
 }
 
 /**

--- a/tswow-core/Private/TSCreature.cpp
+++ b/tswow-core/Private/TSCreature.cpp
@@ -1165,6 +1165,16 @@ void TSCreature::SetReactState(uint8 state)
 }
 
 /**
+ * Gets how a [Creature] responds to being attacked.
+ *
+ * @return uint8 0 = Passive, 1, = Defensive, 2 = Aggressive
+ */
+uint8 TSCreature::GetReactState()
+{
+    return static_cast<uint8>(creature->GetReactState());
+}
+
+/**
  * Save the [Creature] in the database.
  */
 void TSCreature::SaveToDB()

--- a/tswow-core/Private/TSCreature.cpp
+++ b/tswow-core/Private/TSCreature.cpp
@@ -1155,6 +1155,16 @@ void TSCreature::AttackStart(TSUnit _target)
 }
 
 /**
+ * Sets how a [Creature] responds to being attacked.
+ *
+ * @param uint8 state : the state to set. 0 = Passive, 1, = Defensive, 2 = Aggressive
+ */
+void TSCreature::SetReactState(uint8 state)
+{
+    creature->SetReactState(static_cast<ReactStates>(state));
+}
+
+/**
  * Save the [Creature] in the database.
  */
 void TSCreature::SaveToDB()

--- a/tswow-core/Private/TSCreature.cpp
+++ b/tswow-core/Private/TSCreature.cpp
@@ -1154,24 +1154,14 @@ void TSCreature::AttackStart(TSUnit _target)
     creature->AI()->AttackStart(target);
 }
 
-/**
- * Sets how a [Creature] responds to being attacked.
- *
- * @param uint8 state : the state to set. 0 = Passive, 1, = Defensive, 2 = Aggressive
- */
-void TSCreature::SetReactState(uint8 state)
+void TSCreature::SetReactState(ReactStates state)
 {
-    creature->SetReactState(static_cast<ReactStates>(state));
+    creature->SetReactState(state);
 }
 
-/**
- * Gets how a [Creature] responds to being attacked.
- *
- * @return uint8 0 = Passive, 1, = Defensive, 2 = Aggressive
- */
-uint8 TSCreature::GetReactState()
+ReactStates TSCreature::GetReactState()
 {
-    return static_cast<uint8>(creature->GetReactState());
+    return creature->GetReactState();
 }
 
 /**

--- a/tswow-core/Public/TSCreature.h
+++ b/tswow-core/Public/TSCreature.h
@@ -109,8 +109,8 @@ public:
     void CallForHelp(float radius);
     void FleeToGetAssistance();
     void AttackStart(TSUnit target);
-    void SetReactState(uint8 state);
-    uint8 GetReactState();
+    void SetReactState(ReactStates state);
+    ReactStates GetReactState();
     void SaveToDB();
     TSUnit SelectVictim();
     void UpdateEntry(uint32 entry, uint32 dataGuidLow);

--- a/tswow-core/Public/TSCreature.h
+++ b/tswow-core/Public/TSCreature.h
@@ -109,6 +109,7 @@ public:
     void CallForHelp(float radius);
     void FleeToGetAssistance();
     void AttackStart(TSUnit target);
+    void SetReactState(uint8 state);
     void SaveToDB();
     TSUnit SelectVictim();
     void UpdateEntry(uint32 entry, uint32 dataGuidLow);

--- a/tswow-core/Public/TSCreature.h
+++ b/tswow-core/Public/TSCreature.h
@@ -109,8 +109,8 @@ public:
     void CallForHelp(float radius);
     void FleeToGetAssistance();
     void AttackStart(TSUnit target);
-    void SetReactState(ReactStates state);
-    ReactStates GetReactState();
+    void SetReactState(uint8 state);
+    uint8 GetReactState();
     void SaveToDB();
     TSUnit SelectVictim();
     void UpdateEntry(uint32 entry, uint32 dataGuidLow);

--- a/tswow-core/Public/TSCreature.h
+++ b/tswow-core/Public/TSCreature.h
@@ -110,6 +110,7 @@ public:
     void FleeToGetAssistance();
     void AttackStart(TSUnit target);
     void SetReactState(uint8 state);
+    uint8 GetReactState();
     void SaveToDB();
     TSUnit SelectVictim();
     void UpdateEntry(uint32 entry, uint32 dataGuidLow);

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -2975,6 +2975,13 @@ declare interface TSCreature extends TSUnit {
     SetReactState(state: uint8) : void
 
     /**
+     * Gets how a [Creature] responds to being attacked.
+     *
+     * @return uint8 0 = Passive, 1, = Defensive, 2 = Aggressive
+     */
+    GetReactState() : uint8
+
+    /**
      * Save the [Creature] in the database.
      */
     SaveToDB() : void

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -96,6 +96,7 @@ declare const enum Powers /**@realType:int8 */ {
     RUNIC_POWER                   = 6,
 } /**@realType:int8 */
 declare const enum CreatureType {} /** SharedDefines.h:CreatureType */
+declare const enum ReactStates {} /** UnitDefines.h:ReactStates */
 declare const enum LocaleConstant {} /** Common.h:LocaleConstant */
 declare const enum UnitMoveType {} /** UnitDefines.h:UnitMoveType */
 declare const enum MovementGeneratorType {} /** MovementDefines.h:MovementGeneratorType */
@@ -2970,16 +2971,16 @@ declare interface TSCreature extends TSUnit {
     /**
      * Sets how a [Creature] responds to being attacked.
      *
-     * @param uint8 state : the state to set. 0 = Passive, 1, = Defensive, 2 = Aggressive
+     * @param ReactStates state : the state to set.
      */
-    SetReactState(state: uint8) : void
+    SetReactState(state: ReactStates) : void
 
     /**
      * Gets how a [Creature] responds to being attacked.
      *
-     * @return uint8 0 = Passive, 1, = Defensive, 2 = Aggressive
+     * @return ReactStates. 0 = Passive, 1, = Defensive, 2 = Aggressive
      */
-    GetReactState() : uint8
+    GetReactState() : ReactStates
 
     /**
      * Save the [Creature] in the database.

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -2968,6 +2968,13 @@ declare interface TSCreature extends TSUnit {
     AttackStart(target : TSUnit) : void
 
     /**
+     * Sets how a [Creature] responds to being attacked.
+     *
+     * @param uint8 state : the state to set. 0 = Passive, 1, = Defensive, 2 = Aggressive
+     */
+    SetReactState(state: uint8) : void
+
+    /**
      * Save the [Creature] in the database.
      */
     SaveToDB() : void


### PR DESCRIPTION
Closes https://github.com/tswow/tswow/issues/424

Adds support for getting and setting the react state of creatures via livescripts.

Example:

When a wolf in human starting area reaches < 50% hp they'll start running towards one specific spot, after 10 seconds they become aggressive and continue combat. 

Use cases: Most bosses with an in combat event eg Smite, Onyxia.

```ts
export function Main(events: TSEvents) {
    events.CreatureID.OnCreate(299, (creature, cancel) => {
        creature.SetBool('canSwap', true);

        console.log(`Current State: ${creature.GetReactState()}`);
    });

    events.CreatureID.OnUpdateAI(299, (creature, diff) => {
        if (creature.GetHealthPct() < 50 && creature.GetBool('canSwap', true)) {
            creature.SetBool('canSwap', false);

            creature.SendUnitSay('Yelp!', 0);
            creature.SetReactState(0);
            creature.MoveTo(0, <float> -8966.261719, <float> -112.267311, <float> 84.030426, true);
        
            console.log(`Current State: ${creature.GetReactState()}`);

            creature.AddTimer(10000, 1, 0, (owner, timer) => {
                let wolf = owner.ToCreature();

                wolf.SetReactState(2);

                console.log(`Current State: ${wolf.GetReactState()}`);
            });
        }
    });
}
```