### PR TITLE
Level Check LearnClassSpells

### DIFF
--- a/tswow-core/Private/TSPlayer.cpp
+++ b/tswow-core/Private/TSPlayer.cpp
@@ -3802,7 +3802,7 @@ void TSPlayer::AddItemToSlotRaw(uint8 bag, uint8 slot, uint32 itemId, uint32 cou
     if (item) player->SendNewItem(item, count, true, false);
 }
 
-void TSPlayer::LearnClassSpells(bool trainer, bool quests, bool levelLimited)
+void TSPlayer::LearnClassSpells(bool trainer, bool quests, bool limitQuestsByLevel)
 {
     ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(player->GetClass());
     if (!classEntry)
@@ -3842,7 +3842,7 @@ void TSPlayer::LearnClassSpells(bool trainer, bool quests, bool levelLimited)
         {
             if (quest.GetRequiredClasses() && player->SatisfyQuestClass(&quest, false))
             {
-                if (levelLimited && ! player->SatisfyQuestLevel(&quest, false)) {
+                if (limitQuestsByLevel && ! player->SatisfyQuestLevel(&quest, false)) {
                     continue;
                 }
 

--- a/tswow-core/Private/TSPlayer.cpp
+++ b/tswow-core/Private/TSPlayer.cpp
@@ -3802,7 +3802,7 @@ void TSPlayer::AddItemToSlotRaw(uint8 bag, uint8 slot, uint32 itemId, uint32 cou
     if (item) player->SendNewItem(item, count, true, false);
 }
 
-void TSPlayer::LearnClassSpells(bool trainer, bool quests)
+void TSPlayer::LearnClassSpells(bool trainer, bool quests, bool levelLimited)
 {
     ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(player->GetClass());
     if (!classEntry)
@@ -3841,7 +3841,13 @@ void TSPlayer::LearnClassSpells(bool trainer, bool quests)
         for (auto const& [id, quest] : sObjectMgr->GetQuestTemplates())
         {
             if (quest.GetRequiredClasses() && player->SatisfyQuestClass(&quest, false))
+            {
+                if (levelLimited && ! player->SatisfyQuestLevel(&quest, false)) {
+                    continue;
+                }
+
                 player->LearnQuestRewardedSpells(&quest);
+            }
         }
     }
 }

--- a/tswow-core/Public/TSPlayer.h
+++ b/tswow-core/Public/TSPlayer.h
@@ -261,7 +261,7 @@ public:
 	void ModifyMoney(int32 amt);
 	void LearnSpell(uint32 id);
 	void LearnTalent(uint32 id, uint32 rank);
-	void LearnClassSpells(bool trainer, bool quests, bool levelLimited);
+	void LearnClassSpells(bool trainer, bool quests, bool limitQuestsByLevel = false);
 	void ResurrectPlayer(float percent, bool sickness);
 	void GossipMenuAddItem(uint32 _icon, TSString msg, uint32 _sender = 0, uint32 _intid = 0, bool _code = false, TSString _promptMsg = JSTR(""), uint32 _money = 0);
 	void GossipComplete();

--- a/tswow-core/Public/TSPlayer.h
+++ b/tswow-core/Public/TSPlayer.h
@@ -261,7 +261,7 @@ public:
 	void ModifyMoney(int32 amt);
 	void LearnSpell(uint32 id);
 	void LearnTalent(uint32 id, uint32 rank);
-	void LearnClassSpells(bool trainer, bool quests);
+	void LearnClassSpells(bool trainer, bool quests, bool levelLimited);
 	void ResurrectPlayer(float percent, bool sickness);
 	void GossipMenuAddItem(uint32 _icon, TSString msg, uint32 _sender = 0, uint32 _intid = 0, bool _code = false, TSString _promptMsg = JSTR(""), uint32 _money = 0);
 	void GossipComplete();

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -201,7 +201,7 @@ declare interface TSAchievementCriteriaEntry
 }
 
 declare interface TSPlayer extends TSUnit {
-    LearnClassSpells(trainer: boolean, quests: boolean, levelLimited: boolean);
+    LearnClassSpells(trainer: boolean, quests: boolean, limitQuestsByLevel?: boolean);
     SendData(data: any)
     SendUpdateWorldState(worldState: uint32, value: uint32);
     SetBankBagSlotCount(count: uint8)

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -201,7 +201,7 @@ declare interface TSAchievementCriteriaEntry
 }
 
 declare interface TSPlayer extends TSUnit {
-    LearnClassSpells(trainer: boolean, quests: boolean);
+    LearnClassSpells(trainer: boolean, quests: boolean, levelLimited: boolean);
     SendData(data: any)
     SendUpdateWorldState(worldState: uint32, value: uint32);
     SetBankBagSlotCount(count: uint8)


### PR DESCRIPTION
Closes https://github.com/tswow/tswow/issues/432

Adds an extra parameter to the LearnClassSpells function that allows to limit the spells rewarded from class quests to just those matching your current level. 

Example usage:

```ts
export function Main(events: TSEvents) {
    events.Player.OnLevelChanged((player, oldLevel) => {
        player.LearnClassSpells(true, true, true);
    });
}
```

With the above when playing as a Warrior and using `.levelup 1` in game you will _not_ learn spells such as Defensive Stance. With it set to false (the old default behaviour) it will teach them at level 2 even though they shouldn't "naturally" get them at that level. 