### PR TITLE
Add Creature Instance Equipment ID.

### DIFF
--- a/tswow-scripts/wotlk/std/Creature/CreatureInstance.ts
+++ b/tswow-scripts/wotlk/std/Creature/CreatureInstance.ts
@@ -193,6 +193,11 @@ export class CreatureInstance extends MainEntity<creatureRow> {
      * The boss id of this creature in the instance it belongs to
      */
     get Boss() { return new CreatureInstanceBoss(this); }
+
+    /**
+     * The Equipment from `creature_equip_template` the instance should use.
+     */
+    get EquipmentID() { return this.wrap(this.row.equipment_id); }
 }
 
 // write boss maps once we're done writing, since the map could change before then


### PR DESCRIPTION
Just means I don't have to do `spawn.row.equipment_id.set(1);` all the time breaking the method chaining.