### PR TITLE
Quest Info Support

### DIFF
--- a/tswow-scripts/wotlk/std/Quest/Quest.ts
+++ b/tswow-scripts/wotlk/std/Quest/Quest.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+import { makeEnumCell } from "../../../data/cell/cells/EnumCell";
 import { makeMaskCell32 } from "../../../data/cell/cells/MaskCell";
 import { Transient } from "../../../data/cell/serialization/Transient";
 import { CellSystem } from "../../../data/cell/systems/CellSystem";
@@ -27,6 +28,7 @@ import { QuestAddon } from "./QuestAddon";
 import { QuestFlags } from "./QuestFlags";
 import { QuestGameEventCondition } from "./QuestGameEventPoints";
 import { QuestNPC } from "./QuestGiver";
+import { QuestInfoTypes } from "./QuestInfoTypes";
 import { QuestObjective } from "./QuestObjective";
 import { QuestPOIs } from "./QuestPOI";
 import { QuestReward } from "./QuestReward";
@@ -105,6 +107,8 @@ export class Quest extends MainEntityID<quest_templateRow> {
     get RaceMask() {
         return makeMaskCell32(RaceMask, this, this.row.AllowableRaces, false);
     }
+
+    get QuestInfo() { return makeEnumCell(QuestInfoTypes, this, this.row.QuestInfoID); }
 
     readonly GameEventPoints = new QuestGameEventCondition(this);
 }

--- a/tswow-scripts/wotlk/std/Quest/QuestInfoTypes.ts
+++ b/tswow-scripts/wotlk/std/Quest/QuestInfoTypes.ts
@@ -1,0 +1,13 @@
+export enum QuestInfoTypes {
+    GROUP = 1,
+    LIFE = 21,
+    PVP = 41,
+    RAID = 62,
+    DUNGEON = 81,
+    WORLD_EVENT = 82,
+    LEGENDARY = 83,
+    ESCORT = 84,
+    HEROIC = 85,
+    RAID_10 = 88,
+    RAID_25 = 89,
+}


### PR DESCRIPTION
Adds access to the `QuestInfoID` column to the Quest entity. Added as an enum cell with a new enum added based on the "normal" values that can be gotten from the [DBC](https://wow.tools/dbc/?dbc=questinfo&build=3.3.5.12340#page=1).