### PR TITLE
OnMovementInform Event

### DIFF
--- a/tswow-core/Private/TSEventsLua.cpp
+++ b/tswow-core/Private/TSEventsLua.cpp
@@ -263,6 +263,7 @@ void TSLua::load_events(sol::state& state)
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnCalcColorCode);
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnCalcGain);
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnCalcBaseGain);
+    LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnMovementInform);
 
     auto gameobject_events = state.new_usertype<TSEvents::GameObjectEvents>("GameObjectEvents");
     LUA_MAPPED_HANDLE(gameobject_events, GameObjectEvents, OnUpdate);

--- a/tswow-core/Public/TSEvents.h
+++ b/tswow-core/Public/TSEvents.h
@@ -540,6 +540,7 @@ struct TSEvents
         ID_EVENT(OnWaypointStarted, TSCreature, TSNumber<uint32>, TSNumber<uint32>)
         ID_EVENT(OnWaypointReached, TSCreature, TSNumber<uint32>, TSNumber<uint32>)
         ID_EVENT(OnWaypointPathEnded, TSCreature, TSNumber<uint32>, TSNumber<uint32>)
+        ID_EVENT(OnMovementInform, TSCreature, TSNumber<uint32>, TSNumber<uint32>)
         ID_EVENT(OnPassengerBoarded, TSCreature, TSUnit, TSNumber<int8>, bool)
         ID_EVENT(OnSpellClick, TSCreature, TSUnit, bool)
         ID_EVENT(OnUpdateAI, TSCreature, TSNumber<uint32>)

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -8247,6 +8247,9 @@ declare namespace _hidden {
         OnWaypointPathEnded(callback: (creature: TSCreature, id: uint32, path: uint32)=>void): T;
         OnWaypointPathEnded(id: EventID, callback: (creature: TSCreature, id: uint32, path: uint32)=>void): T;
 
+        OnMovementInform(callback: (creature: TSCreature, type: uint32, id: uint32)=>void): T;
+        OnMovementInform(id: EventID, callback: (creature: TSCreature, type: uint32, id: uint32)=>void): T;
+
         OnPassengerBoarded(callback: (creature: TSCreature, passenger: TSUnit, seatId: int8, isFirst: boolean)=>void): T;
         OnPassengerBoarded(id: EventID, callback: (creature: TSCreature, passenger: TSUnit, seatId: int8, isFirst: boolean)=>void): T;
 


### PR DESCRIPTION
- Adds an OnMovementInform event that is essentially a replacement for `MovementInform` which is heavily used by TC boss scripts.
- Fire in all the relevant places with matching type and ID same as `MovementInform` does. (See related core side PR).

Rough example usage.

```ts
        events.Creature.OnMovementInform(NPC_WEEGLI, (creature, type, id) => {
            if (type != MovementGeneratorType.POINT) {
                return;
            }

            console.log(`OnMovementInform: ${type} - ${id}`);

            if (id == 1) {
                creature.SendUnitSay('They\'re coming!', 0);
                creature.PerformEmote(5);
                creature.SetWalk(false);
                creature.MoveTo(2, WEEGLI_RETREAT.x, WEEGLI_RETREAT.y, WEEGLI_RETREAT.z, true, WEEGLI_RETREAT.o);
            }
        });
```