### PR TITLE
Add OnCalculateFeralAttackPower Hook

### DIFF
--- a/tswow-core/Private/TSEventsLua.cpp
+++ b/tswow-core/Private/TSEventsLua.cpp
@@ -362,6 +362,7 @@ void TSLua::load_events(sol::state& state)
     LUA_MAPPED_HANDLE(item_events, ItemEvents, OnLFGRollEarly);
     LUA_MAPPED_HANDLE(item_events, ItemEvents, OnDestroyEarly);
     LUA_MAPPED_HANDLE(item_events, ItemEvents, OnTakenAsLoot);
+    LUA_MAPPED_HANDLE(item_events, ItemEvents, OnCalculateFeralAttackPower);
 
     auto quest_events = state.new_usertype<TSEvents::QuestEvents>("QuestEvents");
     LUA_MAPPED_HANDLE(quest_events, QuestEvents, OnAccept);

--- a/tswow-core/Public/TSEvents.h
+++ b/tswow-core/Public/TSEvents.h
@@ -804,6 +804,7 @@ struct TSEvents
          ID_EVENT(OnLFGRollEarly, TSItemTemplate, TSWorldObject looted, TSPlayer looter, TSMutableNumber<int32> result)
          ID_EVENT(OnDestroyEarly, TSItem, TSPlayer, TSMutable<bool,bool>)
          ID_EVENT(OnTakenAsLoot, TSItem, TSLootItem, TSLoot, TSPlayer)
+         ID_EVENT(OnCalculateFeralAttackPower, TSItemTemplate, TSNumber<int32>, TSMutableNumber<int32> result)
      } Item;
 
     struct QuestEvents : public TSMappedEventsRegistry

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -8874,6 +8874,9 @@ declare namespace _hidden {
 
         OnTakenAsLoot(callback: (item: TSItem, lootItem: TSLootItem, loot: TSLoot, player: TSPlayer)=>void);
         OnTakenAsLoot(id: EventID, callback: (item: TSItem, lootItem: TSLootItem, loot: TSLoot, player: TSPlayer)=>void);
+
+        OnCalculateFeralAttackPower(callback: (item: TSItemTemplate, extra: TSNumber<int32>, result: TSMutableNumber<int32>)=>void);
+        OnCalculateFeralAttackPower(id: EventID, callback: (item: TSItemTemplate, extra: TSNumber<int32>, result: TSMutableNumber<int32>)=>void);
     }
 
     export class GameObject<T> {


### PR DESCRIPTION
Used to be able to change the formula of feral attack power.

https://wowpedia.fandom.com/wiki/Feral_attack_power

Example usage:

```ts
export namespace FeralAttackPower {
    export function Init(events: TSEvents) {
        events.Item.OnCalculateFeralAttackPower((item, extra, result) => {
            if (item.GetItemLevel() >= 64) {
                const feral = ((extra + item.GetDPS()) - 54.8) * 14;

                result.set(<int32> feral);
            } else {
                const feral = ((extra + item.GetDPS()) - 6) * 1.06;

                result.set(<int32> feral);
            }
        });
    }
}
```