### PR TITLE
Add WorldMapFrame to global type declarations for Addon

### DIFF
--- a/misc/install-config/include-addon/global.d.ts
+++ b/misc/install-config/include-addon/global.d.ts
@@ -13889,6 +13889,7 @@ declare const PlayerFrame: WoWAPI.Frame;
 declare const TargetFrame: WoWAPI.Frame;
 declare const FocusFrame: WoWAPI.Frame;
 declare const WorldFrame: WoWAPI.Frame;
+declare const WorldMapFrame: WoWAPI.Frame;
 declare const ChatFrame1: WoWAPI.Frame;
 
 declare function loadstring(code: string, name?: string): ()=>void;


### PR DESCRIPTION
It works perfectly with LUA but it seems Typescript is missing the type.