### PR TITLE
Add TSGUID != Operator

### DIFF
--- a/tswow-core/Private/TSGUID.cpp
+++ b/tswow-core/Private/TSGUID.cpp
@@ -30,6 +30,11 @@ bool TSGUID::operator==(TSGUID const& oth) const
     return m_guid == oth.m_guid;
 }
 
+bool TSGUID::operator!=(TSGUID const& oth) const
+{
+    return m_guid != oth.m_guid;
+}
+
 ObjectGuid TSGUID::asGUID() const
 {
     return ObjectGuid(m_guid);

--- a/tswow-core/Public/TSGUID.h
+++ b/tswow-core/Public/TSGUID.h
@@ -13,6 +13,7 @@ public:
     TSNumber<uint32> GetType() const;
     TSNumber<uint32> GetEntry() const;
     bool operator==(TSGUID const& oth) const;
+    bool operator!=(TSGUID const& oth) const;
     TSGUID* operator->() { return this; }
     bool IsEmpty()             const;
     bool IsCreature()          const;


### PR DESCRIPTION
Adding this just because it saves me a bunch of rewrites. When it was uint64 based doing `x.GetGUID() != y.GetGUID()` was an easy comparison to do so we've used it a lot.