### PR TITLE
Instance Helpers

### DIFF
--- a/tswow-core/Private/TSInstance.cpp
+++ b/tswow-core/Private/TSInstance.cpp
@@ -292,3 +292,33 @@ bool TSBossInfo::IsWithinBoundary(TSWorldObject obj)
 #endif
     return true;
 }
+
+TSNumber<uint32> TSInstance::GetInstanceData(uint32 id)
+{
+    return m_script->GetData(id);
+}
+
+void TSInstance::SetInstanceData(uint32 id, uint32 data)
+{
+    m_script->SetData(id, data);
+}
+
+TSNumber<uint64> TSInstance::GetInstanceData64(uint32 id)
+{
+    return m_script->GetData64(id);
+}
+
+void TSInstance::SetInstanceData64(uint32 id, uint64 data)
+{
+    m_script->SetData64(id, data);
+}
+
+TSGUID TSInstance::GetInstanceGuidData(uint32 id)
+{
+    return TSGUID(m_script->GetGuidData(id));
+}
+
+void TSInstance::SetInstanceGuidData(uint32 id, TSGUID data)
+{
+    m_script->SetGuidData(id, data->asGUID());
+}

--- a/tswow-core/Private/TSInstance.cpp
+++ b/tswow-core/Private/TSInstance.cpp
@@ -313,12 +313,12 @@ void TSInstance::SetInstanceData64(uint32 id, uint64 data)
     m_script->SetData64(id, data);
 }
 
-TSGUID TSInstance::GetInstanceGuidData(uint32 id)
+TSGUID TSInstance::GetInstanceGUIDData(uint32 id)
 {
     return TSGUID(m_script->GetGuidData(id));
 }
 
-void TSInstance::SetInstanceGuidData(uint32 id, TSGUID data)
+void TSInstance::SetInstanceGUIDData(uint32 id, TSGUID data)
 {
     m_script->SetGuidData(id, data->asGUID());
 }

--- a/tswow-core/Public/TSInstance.h
+++ b/tswow-core/Public/TSInstance.h
@@ -73,4 +73,10 @@ public:
     TSNumber<uint32> GetTeamIDInInstance();
     TSNumber<uint32> GetFactionInInstance();
     TSBossInfo GetBossInfo(uint32 id);
+    TSNumber<uint32> GetInstanceData(uint32 id);
+    void SetInstanceData(uint32 id, uint32 data);
+    TSNumber<uint64> GetInstanceData64(uint32 id);
+    void SetInstanceData64(uint32 id, uint64 data);
+    TSGUID GetInstanceGuidData(uint32 id);
+    void SetInstanceGuidData(uint32 id, TSGUID data);
 };

--- a/tswow-core/Public/TSInstance.h
+++ b/tswow-core/Public/TSInstance.h
@@ -77,6 +77,6 @@ public:
     void SetInstanceData(uint32 id, uint32 data);
     TSNumber<uint64> GetInstanceData64(uint32 id);
     void SetInstanceData64(uint32 id, uint64 data);
-    TSGUID GetInstanceGuidData(uint32 id);
-    void SetInstanceGuidData(uint32 id, TSGUID data);
+    TSGUID GetInstanceGUIDData(uint32 id);
+    void SetInstanceGUIDData(uint32 id, TSGUID data);
 };

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -4816,12 +4816,12 @@ declare interface TSInstance extends TSMap {
     GetFactionInInstance(): TSNumber<uint32>
     GetBossInfo(id: uint32): TSBossInfo
     RemoveFromMap(player:TSPlayer, deleteFromWorld: boolean): void
-    GetInstanceData(): TSNumber<uint32>;
+    GetInstanceData(id: uint32): TSNumber<uint32>;
     SetInstanceData(id: uint32, data: uint32): void;
     GetInstanceData64(id: uint32): TSNumber<uint64>;
     SetInstanceData64(id: uint32, data: uint64): void;
-    GetInstanceGuidData(id: uint32): TSGUID;
-    SetInstanceGuidData(id: uint32, data: TSGUID): void;
+    GetInstanceGUIDData(id: uint32): TSGUID;
+    SetInstanceGUIDData(id: uint32, data: TSGUID): void;
 }
 
 declare interface TSGameObject extends TSWorldObject {

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -4816,6 +4816,12 @@ declare interface TSInstance extends TSMap {
     GetFactionInInstance(): TSNumber<uint32>
     GetBossInfo(id: uint32): TSBossInfo
     RemoveFromMap(player:TSPlayer, deleteFromWorld: boolean): void
+    GetInstanceData(): TSNumber<uint32>;
+    SetInstanceData(id: uint32, data: uint32): void;
+    GetInstanceData64(id: uint32): TSNumber<uint64>;
+    SetInstanceData64(id: uint32, data: uint64): void;
+    GetInstanceGuidData(id: uint32): TSGUID;
+    SetInstanceGuidData(id: uint32, data: TSGUID): void;
 }
 
 declare interface TSGameObject extends TSWorldObject {

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -4790,7 +4790,7 @@ declare interface TSBossInfo {
 
 declare interface TSInstance extends TSMap {
     IsNull(): bool;
-    SaveToDB(): void;
+    SaveInstanceToDB(): void;
     IsEncounterInProgress(): bool;
     GetEncounterCount(): TSNumber<uint32>
     GetObjectGUID(type: uint32): TSNumber<uint64>


### PR DESCRIPTION
Gives access to the generic `SetData` functions TC uses in a lot of instance / boss scripts. Also fixes an issue with `SaveInstanceToDB` being named wrong in global.d.ts