### PR TITLE
Fix Area Trigger Event Firing

### DIFF
--- a/tswow-core/Private/TSEventsLua.cpp
+++ b/tswow-core/Private/TSEventsLua.cpp
@@ -378,10 +378,9 @@ void TSLua::load_events(sol::state& state)
     LUA_MAPPED_HANDLE(quest_events, QuestEvents, OnStatusChanged);
     LUA_MAPPED_HANDLE(quest_events, QuestEvents, OnSpellFinish);
 
-#if TRINITY
     auto area_trigger_events = state.new_usertype<TSEvents::AreaTriggerEvents>("AreaTriggerEvents");
     LUA_MAPPED_HANDLE(area_trigger_events, AreaTriggerEvents, OnTrigger);
-#endif
+
     auto gameevent_events = state.new_usertype<TSEvents::GameEventsEvents>("GameEventsEvents");
     LUA_MAPPED_HANDLE(gameevent_events, GameEventsEvents, OnStart);
     LUA_MAPPED_HANDLE(gameevent_events, GameEventsEvents, OnUpdateState);

--- a/tswow-core/Public/TSAreaTrigger.h
+++ b/tswow-core/Public/TSAreaTrigger.h
@@ -22,8 +22,6 @@
 struct AreaTriggerEntry;
 struct TSAreaTriggerEvents;
 
-#if TRINITY
-
 class TC_GAME_API TSAreaTriggerEntry {
     AreaTriggerEntry* m_entry;
 public:
@@ -47,4 +45,3 @@ public:
 
 void InitializeAreaTriggerEvents(uint32 entry, TSAreaTriggerEvents* events);
 TSAreaTriggerEvents* GetAreaTriggerEvents(uint32 entry);
-#endif

--- a/tswow-core/Public/TSEvents.h
+++ b/tswow-core/Public/TSEvents.h
@@ -832,12 +832,11 @@ struct TSEvents
         ID_EVENT(OnStatusChanged, TSQuest, TSPlayer)
         ID_EVENT(OnRewardXP, TSQuest, TSPlayer, TSMutableNumber<uint32>)
     } Quest;
-#if TRINITY
+
     struct AreaTriggerEvents : public TSMappedEventsDirect {
         EVENTS_HEADER(AreaTriggerEvents)
-        ID_EVENT(OnTrigger, TSNumber<uint8>, TSPlayer, TSMutable<bool,bool>)
+        ID_EVENT(OnTrigger, TSAreaTriggerEntry, TSPlayer, TSMutable<bool,bool>)
     } AreaTrigger;
-#endif
 
     struct GameEventsEvents : public TSMappedEventsDirect {
         EVENTS_HEADER(GameEventsEvents)


### PR DESCRIPTION
Closes https://github.com/tswow/tswow/issues/742

Test cases:

```ts
events.AreaTrigger.OnTrigger((trigger, player, cancel) => {
    console.log(`\nTrigger Reached! - ${trigger.GetEntry()}\n`)

    cancel.set(true);
});
```

```ts
events.AreaTrigger.OnTrigger(1526, (trigger, player, cancel) => {
    console.log(`\nTrigger Reached! - ${trigger.GetEntry()}\n`)

    cancel.set(true);
});
```