### PR TITLE
Swap SWC to sync

### DIFF
--- a/tswow-scripts/runtime/Datascripts.ts
+++ b/tswow-scripts/runtime/Datascripts.ts
@@ -183,7 +183,7 @@ export class Datascripts {
             term.debug('datascripts', `Compiling datascripts at ${this.path.abs().get()}`)
             wsys.execIn(
                   this.path.dirname().get()
-                , `swc datascripts -d datascripts/build`,'inherit'
+                , `swc datascripts -d datascripts/build --sync`,'inherit'
             )
         } catch(err) {
             this.path.swcrc.remove();


### PR DESCRIPTION
Resolves

```
EMFILE: too many open files, open 'C:\Dev\tswow-epoch\modules\project-epoch\epoch\datascripts\build\maps\instances\blackrock-spire\upper\creatures\bosses\father-flame\waves\wave-4.js'
Successfully compiled: 4094 files with swc (676.37ms)
Failed to compile 50 files with swc.
Error: Failed to compile
    at initialCompilation (C:\Dev\tswow-epoch\node_modules\@swc\cli\lib\swc\dir.js:162:19)
    at async dir (C:\Dev\tswow-epoch\node_modules\@swc\cli\lib\swc\dir.js:222:5)
```

Essentially we hit the windows file handle limit. This actually shouldn't be a problem on linux since you can just up the ulimit so maybe down the line we add a config or --sync build option. 