### PR TITLE
Loading info canequip

### DIFF
--- a/tswow-core/Public/TSEvents.h
+++ b/tswow-core/Public/TSEvents.h
@@ -812,7 +812,7 @@ struct TSEvents
          ID_EVENT(OnCanChangeEquipState, TSItemTemplate, TSMutable<bool,bool>)
          ID_EVENT(OnUnequip, TSItem, TSPlayer, bool, TSMutableNumber<uint32> result)
          ID_EVENT(OnBank, TSItem, TSPlayer, TSNumber<uint8> bag, TSNumber<uint8> slot, bool swap, TSMutableNumber<uint32> result)
-         ID_EVENT(OnCanEquip, TSItem, TSPlayer, TSNumber<uint8> slot, bool swap, TSMutableNumber<uint32> result)
+         ID_EVENT(OnCanEquip, TSItem, TSPlayer, TSNumber<uint8> slot, bool swap, bool not_loading, TSMutableNumber<uint32> result)
          ID_EVENT(OnEquip, TSItem, TSPlayer, TSNumber<uint8> slot, bool isMerge)
          ID_EVENT(OnCanUse, TSItem, TSPlayer, TSMutableNumber<uint32> result)
          ID_EVENT(OnCanUseType, TSItemTemplate, TSPlayer, TSMutableNumber<uint32> result)

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -9086,8 +9086,8 @@ declare namespace _hidden {
         OnBank(callback: (item: TSItem, player: TSPlayer, bag: uint8, slot: uint8, swap: boolean, result: TSMutableNumber<uint32>)=>void);
         OnBank(id: EventID, callback: (item: TSItem, player: TSPlayer, bag: uint8, slot: uint8, swap: boolean, result: TSMutableNumber<uint32>)=>void);
 
-        OnCanEquip(callback: (item: TSItem, player: TSPlayer, slot: EquipmentSlots, swap: boolean, result: TSMutable<InventoryResult,InventoryResult>)=>void);
-        OnCanEquip(id: EventID, callback: (item: TSItem, player: TSPlayer, slot: EquipmentSlots, swap: boolean, result: TSMutable<InventoryResult,InventoryResult>)=>void);
+        OnCanEquip(callback: (item: TSItem, player: TSPlayer, slot: EquipmentSlots, swap: boolean, notLoading: boolean, result: TSMutable<InventoryResult,InventoryResult>)=>void);
+        OnCanEquip(id: EventID, callback: (item: TSItem, player: TSPlayer, slot: EquipmentSlots, swap: boolean, notLoading: boolean, result: TSMutable<InventoryResult,InventoryResult>)=>void);
 
         OnEquip(callback: (item: TSItem, player: TSPlayer, slot: EquipmentSlots, isMerge: boolean)=>void)
         OnEquip(id: EventID, callback: (item: TSItem, player: TSPlayer, slot: EquipmentSlots, isMerge: boolean)=>void)


### PR DESCRIPTION
Relies on https://github.com/tswow/TrinityCore/pull/31

Not sure if submodule stuff is handled correctly in this PR

This commit adds the `not_loading` bool to the OnCanEquip event. This is required if devs want to check that `OnCanEquip` is not called when loading. As equipping of items might depend on _other_ items, which at login are not yet considered equipped, `OnCanEquip` could previously fail.

E.g. this simple example which just checks for a custom strength requirement of an item:
```typescript
events.Item.OnCanEquip((item, player, slot, swap,  result) =>{
        let entry = item.GetEntry()
        let hasTag = HAS_TAG(entry, "wog-core", "stat-req")
        if(hasTag) {
            // Check if the player has not enough strength.
            let strReq = getStrRequirement(entry)
            if (player.GetStat(STAT_STR) < strReq){
                result.set(2)
                player.SendBroadcastMessage(`You require ${strReq} strength`)
            }

        }
    })
```
Currently this would fail on a login if the strength requirement is only hit via other items.
The working code with the fix from this PR looks like this:
```typescript
events.Item.OnCanEquip((item, player, slot, swap, notLoading, result) =>{
        // If we're loading in, we don't want to check for stat requirements, as
        // the server may not consider all the items that may affect the player's
        // stats yet.
        if (!notLoading){
            return
        }
        let entry = item.GetEntry()
        let hasTag = HAS_TAG(entry, "wog-core", "stat-req")
        if(hasTag) {
            // Check if the player has not enough strength.
            let strReq = getStrRequirement(entry)
            if (player.GetStat(STAT_STR) < strReq){
                result.set(2)
                player.SendBroadcastMessage(`You require ${strReq} strength`)
            }

        }
    })
```
