### PR TITLE
Update node to v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "chokidar": "^3.5.2",
         "clipboardy": "^2.3.0",
         "cross-spawn": "^7.0.3",
-        "deasync": "^0.1.21",
+        "deasync": "^0.1.30",
         "extract-zip": "^2.0.1",
         "fs-extra": "^9.0.1",
         "install": "^0.13.0",
@@ -1058,10 +1058,11 @@
       }
     },
     "node_modules/deasync": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz",
-      "integrity": "sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.30.tgz",
+      "integrity": "sha512-OaAjvEQuQ9tJsKG4oHO9nV1UHTwb2Qc2+fadB0VeVtD0Z9wiG1XPGLJ4W3aLhAoQSYTaLROFRbd5X20Dkzf7MQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"
@@ -4503,9 +4504,9 @@
       }
     },
     "deasync": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz",
-      "integrity": "sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.30.tgz",
+      "integrity": "sha512-OaAjvEQuQ9tJsKG4oHO9nV1UHTwb2Qc2+fadB0VeVtD0Z9wiG1XPGLJ4W3aLhAoQSYTaLROFRbd5X20Dkzf7MQ==",
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chokidar": "^3.5.2",
     "clipboardy": "^2.3.0",
     "cross-spawn": "^7.0.3",
-    "deasync": "^0.1.21",
+    "deasync": "^0.1.30",
     "extract-zip": "^2.0.1",
     "fs-extra": "^9.0.1",
     "install": "^0.13.0",

--- a/tswow-scripts/compile/BuildConfig.ts
+++ b/tswow-scripts/compile/BuildConfig.ts
@@ -29,7 +29,7 @@ export const BOOST_URL = 'https://github.com/tswow/misc/releases/download/boost-
 export const MYSQL_URL = 'https://github.com/tswow/misc/releases/download/mysql-5.7.32/mysql-5.7.32-winx64.zip'
 export const OPENSSL_URL = 'https://github.com/tswow/misc/releases/download/openssl-test-1/openssl.zip'
 export const IMAGEMAGICK_URL = 'https://github.com/tswow/misc/releases/download/imagemagick-7.1.0/ImageMagick-7.1.0-portable-Q16-x64.zip'
-export const NODE_URL = 'https://nodejs.org/dist/v18.12.1/node-v18.12.1-win-x64.zip'
+export const NODE_URL = 'https://nodejs.org/dist/v20.18.0/node-v20.18.0-win-x64.zip'
 export const TDB_URL_COMPILE = TDB_URL // change value at reference
 
 // Misc settings

--- a/tswow-scripts/compile/Node.ts
+++ b/tswow-scripts/compile/Node.ts
@@ -16,6 +16,7 @@
  */
 import { ipaths } from '../util/Paths';
 import { isWindows } from '../util/Platform';
+import { wsys } from '../util/System';
 import { NODE_URL } from './BuildConfig';
 import { bpaths } from './CompilePaths';
 import { DownloadFile } from './Downloader';

--- a/tswow-scripts/util/Paths.ts
+++ b/tswow-scripts/util/Paths.ts
@@ -528,8 +528,8 @@ export function BuildPaths(pathIn: string, tdb: string) {
 
         cmakeArchive: file('cmake-3.25.0-win64-x64.zip'),
         mysqlArchive: file('mysql-5.7.32-winx64.zip'),
-        nodeArchive: file('node-v18.12.1-win-x64.zip'),
-        node: dirn('node-v18.12.1-win-x64',{}),
+        nodeArchive: file('node-v20.18.0-win-x64.zip'),
+        node: dirn('node-v20.18.0-win-x64',{}),
 
         sourceAdt: file('source.adt'),
 


### PR DESCRIPTION
With deasync updating we can now go for node 20.

Would be good if someone with a linux machine could try out building datascripts with this and see if it hangs or severely degrades performance before we merge.