### PR TITLE
Add AccessRequirement export

### DIFF
--- a/tswow-scripts/wotlk/wotlk.ts
+++ b/tswow-scripts/wotlk/wotlk.ts
@@ -19,6 +19,7 @@ import { BuildArgs, EmulatorCore } from "../data/Settings";
 import { DBC as _DBC, DBCLoader } from "./DBCFiles";
 import { LUAXML as _LUAXML } from "./luaxml/LUAXML";
 import { SQL as _SQL } from "./SQLFiles";
+import { AccessRequirement, AccessRequirementRegistry } from "./std/AccessRequirement/AccessRequirement";
 import { AchievementRegistry } from "./std/Achievement/Achievement";
 import { AchievementCategoryRegistry } from "./std/Achievement/AchievementCategory";
 import { AreaRegistry } from "./std/Area/Area";
@@ -122,6 +123,7 @@ export const std = {
     Languages : LanguageRegistry,
     Quests : QuestRegistry,
     Titles: TitleRegistry,
+    AccessRequirement: AccessRequirementRegistry,
     Achievements: AchievementRegistry,
     Loot: Loot,
     Items: ItemTemplateRegistry,


### PR DESCRIPTION
`AccessRequirement` _appears_ to be there but wasn't exported in `std/wotlk`. I tested locally and was successfully able to use it after exporting. New to the project, figured I'd send this up and wait for someone to tell me why I'm wrong. 