### PR TITLE
Fix ID range of spawn group templates.

### DIFF
--- a/tswow-scripts/wotlk/std/Misc/Ids.ts
+++ b/tswow-scripts/wotlk/std/Misc/Ids.ts
@@ -938,9 +938,9 @@ export const Ids = {
     instance_encounter_achievement: new DynamicIDGenerator('instance_encounter_achievement',0),
 
     /**
-     * Starts at 105, highest base value is 104
+     * Starts at 1000, highest base value is 325
      */
-    spawn_group_templates: new StaticIDGenerator('spawn_group_template', 105),
+    spawn_group_templates: new StaticIDGenerator('spawn_group_template', 1000),
 
     /**
      * Starts at 100, highest base value is 52


### PR DESCRIPTION
TC has added many more since this was done.

Up the bottom limit and add more of a buffer so we don't have to worry about this.

Anyone who's used this id generator recently is recommended to manually delete ids.txt entries and let it regenerate.