### PR TITLE
Client Extensions: fix for more than 21 races crash

### DIFF
--- a/misc/client-extensions/ClientExtensions/CMakeLists.txt
+++ b/misc/client-extensions/ClientExtensions/CMakeLists.txt
@@ -45,7 +45,7 @@ SET(CLIENT_EXTENSIONS_CPP
     ClientNetwork.cpp
     ClientMPQ.cpp
     ClientExtensions.cpp
-    CHaracters/CharacterFixes.cpp
+    Characters/CharacterFixes.cpp
 )
 
 SET(CLIENT_EXTENSIONS_LUA

--- a/misc/client-extensions/ClientExtensions/CMakeLists.txt
+++ b/misc/client-extensions/ClientExtensions/CMakeLists.txt
@@ -29,6 +29,9 @@ SET(CLIENT_EXTENSIONS_H
     ClientMPQ.h
     FSRoot.h
     lua.hpp
+    ClientExtensions.h
+    Characters/CharacterDefines.h
+    Characters/CharacterFixes.h
 )
 
 SET(CLIENT_EXTENSIONS_CPP
@@ -40,7 +43,10 @@ SET(CLIENT_EXTENSIONS_CPP
     FSRoot.cpp
     TestModule.cpp
     ClientNetwork.cpp
-    ClientMPQ.cpp)
+    ClientMPQ.cpp
+    ClientExtensions.cpp
+    CHaracters/CharacterFixes.cpp
+)
 
 SET(CLIENT_EXTENSIONS_LUA
     ClientNetwork.lua

--- a/misc/client-extensions/ClientExtensions/Characters/CharacterDefines.h
+++ b/misc/client-extensions/ClientExtensions/Characters/CharacterDefines.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <iostream>
+
+// number of races * 2; I've yet to determine what data exactly is stored here
+// actual type doesn't really matter, but to make it neat, I assumed uint32
+static uint32_t memoryTable[64] = { 0 };
+
+// array of pointers to race name strings
+static uint32_t raceNameTable[32] = { 0 };
+
+// something to point to in remaining unfilled entries
+static uint32_t dummy = 0;

--- a/misc/client-extensions/ClientExtensions/Characters/CharacterFixes.cpp
+++ b/misc/client-extensions/ClientExtensions/Characters/CharacterFixes.cpp
@@ -1,0 +1,37 @@
+#include "CharacterFixes.h"
+#include "windows.h"
+
+#include <vector>
+
+void CharacterFixes::CharacterCreationFixes()
+{
+    DWORD flOldProtect = 0;
+    // list of addresses where memoryTable pointer needs to be set
+    std::vector<uint32_t> patchedAddresses = { 0x4E157D, 0x4E16A3, 0x4E15B5, 0x4E20EE, 0x4E222A, 0x4E2127, 0x4E1E94, 0x4E1C3A };
+
+    for (uint8_t i = 0; i < patchedAddresses.size(); i++)
+    {
+        VirtualProtect((LPVOID)patchedAddresses[i], 0x4, PAGE_EXECUTE_READWRITE, &flOldProtect);
+        *(uint32_t*)patchedAddresses[i] = reinterpret_cast<uint32_t>(&memoryTable);
+        VirtualProtect((LPVOID)patchedAddresses[i], 0x4, PAGE_EXECUTE_READ, &flOldProtect);
+    }
+
+    // Name table
+    // there's apparently one more place pointing to that table but doesn't seem to be needed to be fixed
+    SetNewRaceNamePointerTable();
+    VirtualProtect((LPVOID)0x4CDA43, 0x4, PAGE_EXECUTE_READWRITE, &flOldProtect);
+    *(uint32_t*)0x4CDA43 = reinterpret_cast<uint32_t>(&raceNameTable);
+    VirtualProtect((LPVOID)0x4CDA43, 0x4, PAGE_EXECUTE_READ, &flOldProtect);
+
+    return;
+}
+
+void CharacterFixes::SetNewRaceNamePointerTable()
+{
+    memcpy(&raceNameTable, (const void*)0xB24180, 0x58);
+
+    for (uint8_t i = 22; i < 32; i++)
+        raceNameTable[i] = reinterpret_cast<uint32_t>(&dummy);
+
+    return;
+}

--- a/misc/client-extensions/ClientExtensions/Characters/CharacterFixes.h
+++ b/misc/client-extensions/ClientExtensions/Characters/CharacterFixes.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "CharacterDefines.h"
+
+class CharacterFixes {
+private:
+    static void CharacterCreationFixes();
+    static void SetNewRaceNamePointerTable();
+    friend class ClientExtensions;
+};

--- a/misc/client-extensions/ClientExtensions/ClientExtensions.cpp
+++ b/misc/client-extensions/ClientExtensions/ClientExtensions.cpp
@@ -1,0 +1,5 @@
+#include "ClientExtensions.h"
+
+void ClientExtensions::initialize() {
+    CharacterFixes::CharacterCreationFixes();
+}

--- a/misc/client-extensions/ClientExtensions/ClientExtensions.h
+++ b/misc/client-extensions/ClientExtensions/ClientExtensions.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "Characters/CharacterFixes.h"
+
+class ClientExtensions {
+private:
+    static void initialize();
+    friend class Main;
+};

--- a/misc/client-extensions/ClientExtensions/Main.cpp
+++ b/misc/client-extensions/ClientExtensions/Main.cpp
@@ -5,6 +5,7 @@
 #include "Logger.h"
 #include "ClientArguments.h"
 #include "ClientNetwork.h"
+#include "ClientExtensions.h"
 #include "scripts.generated.h"
 
 class Main
@@ -17,6 +18,7 @@ public:
         __init_scripts();
         ClientNetwork::initialize();
         ClientArguments::initialize(GetCommandLineA());
+        ClientExtensions::initialize();
         ClientDetours::Apply();
     }
 };


### PR DESCRIPTION
Title probably says it all, but to summarize, when you add races with ids 22 and above, client starts to crash due to not having enough space - various places in client point to address in read/write block in .data that's 176 bytes in size (number of entries in ChrRace.dbc + 1 multiplied by 8 - well, technically by 2 * 4 according to code), which results in client attempts to write where it shouldn't if race id is equal or above 22.
This commit changes that, allocating 256 bytes (so 32 * 8) in ClientExtensions.dll and pointing various functions to that memory on dll attach - no more crashes (unless race id is equal or above 32, but that's its own can of worms so skipping it for now).