### PR TITLE
Tooltip extension: rune cost moved to dll

### DIFF
--- a/misc/client-extensions/ClientExtensions/CMakeLists.txt
+++ b/misc/client-extensions/ClientExtensions/CMakeLists.txt
@@ -30,8 +30,11 @@ SET(CLIENT_EXTENSIONS_H
     FSRoot.h
     lua.hpp
     ClientExtensions.h
+    SharedDefines.h
     Characters/CharacterDefines.h
     Characters/CharacterFixes.h
+    Tooltip/TooltipDefines.h
+    Tooltip/SpellTooltipExtensions.h
 )
 
 SET(CLIENT_EXTENSIONS_CPP
@@ -46,6 +49,7 @@ SET(CLIENT_EXTENSIONS_CPP
     ClientMPQ.cpp
     ClientExtensions.cpp
     Characters/CharacterFixes.cpp
+    Tooltip/SpellTooltipExtensions.cpp
 )
 
 SET(CLIENT_EXTENSIONS_LUA

--- a/misc/client-extensions/ClientExtensions/ClientExtensions.cpp
+++ b/misc/client-extensions/ClientExtensions/ClientExtensions.cpp
@@ -2,4 +2,5 @@
 
 void ClientExtensions::initialize() {
     CharacterFixes::CharacterCreationFixes();
+    TooltipExtensions::Apply();
 }

--- a/misc/client-extensions/ClientExtensions/ClientExtensions.cpp
+++ b/misc/client-extensions/ClientExtensions/ClientExtensions.cpp
@@ -2,5 +2,5 @@
 
 void ClientExtensions::initialize() {
     CharacterFixes::CharacterCreationFixes();
-    TooltipExtensions::Apply();
+    SpellTooltipExtensions::Apply();
 }

--- a/misc/client-extensions/ClientExtensions/ClientExtensions.h
+++ b/misc/client-extensions/ClientExtensions/ClientExtensions.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Characters/CharacterFixes.h"
+#include "Tooltip/SpellTooltipExtensions.h"
 
 class ClientExtensions {
 private:

--- a/misc/client-extensions/ClientExtensions/ClientMPQ.cpp
+++ b/misc/client-extensions/ClientExtensions/ClientMPQ.cpp
@@ -1,55 +1,8 @@
 #include "Logger.h"
 #include "CustompacketChunk.h"
-#include "ClientMacros.h"
+#include "SharedDefines.h"
 
 #include "windows.h"
-
-CLIENT_FUNCTION(
-      SFileOpenFile
-    , 0x00424F80
-    , __stdcall
-    , int
-    , (
-          char const* filename
-        , HANDLE* a2 /*file handle out*/
-        )
-)
-
-CLIENT_FUNCTION(
-      SFileGetFileSize
-    , 0x004218C0
-    , __stdcall
-    , DWORD /*lowest 32 bits in size*/
-    , (
-            HANDLE handle
-        , DWORD* highSize /*highest 32 bits in size*/
-        )
-)
-
-CLIENT_FUNCTION(
-        SFileReadFile
-    , 0x00422530
-    , __stdcall
-    , int
-    , (
-          HANDLE handle // likely a handle
-        , char* data
-        , DWORD bytesToRead
-        , DWORD* bytesRead
-        , int overlap // just set to 0
-        , int unk // just set to 0
-        )
-)
-
-CLIENT_FUNCTION(
-      SFileCloseFile
-    , 0x00422910
-    , __stdcall
-    , int
-    , (
-            HANDLE a1
-        )
-)
 
 namespace ClientMPQ {
     // todo: it looks like normal GetLastError isn't working here,

--- a/misc/client-extensions/ClientExtensions/SharedDefines.h
+++ b/misc/client-extensions/ClientExtensions/SharedDefines.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "windows.h"
+#include "ClientMacros.h"
+
+#include <functional>
+
+enum SpellFamilyNames
+{
+    SPELLFAMILY_GENERIC     = 0,
+    SPELLFAMILY_UNK1        = 1,
+    SPELLFAMILY_MAGE        = 3,
+    SPELLFAMILY_WARRIOR     = 4,
+    SPELLFAMILY_WARLOCK     = 5,
+    SPELLFAMILY_PRIEST      = 6,
+    SPELLFAMILY_DRUID       = 7,
+    SPELLFAMILY_ROGUE       = 8,
+    SPELLFAMILY_HUNTER      = 9,
+    SPELLFAMILY_PALADIN     = 10,
+    SPELLFAMILY_SHAMAN      = 11,
+    SPELLFAMILY_UNK2        = 12,
+    SPELLFAMILY_POTION      = 13,
+    SPELLFAMILY_DEATHKNIGHT = 15,
+    SPELLFAMILY_PET         = 17
+};
+
+static char* sSpace = " ";
+
+// client functions
+CLIENT_FUNCTION(SFileOpenFile, 0x424F80, __stdcall, int, (char const* filename, HANDLE* a2 /*file handle out*/))
+CLIENT_FUNCTION(SFileGetFileSize, 0x4218C0, __stdcall, DWORD /*lowest 32 bits in size*/, (HANDLE handle, DWORD* highSize /*highest 32 bits in size*/))
+CLIENT_FUNCTION(SFileReadFile, 0x422530, __stdcall, int, (HANDLE handle /*likely a handle*/, char* data, DWORD bytesToRead, DWORD* bytesRead, int overlap /*just set to 0*/, int unk /*just set to 0*/))
+CLIENT_FUNCTION(SFileCloseFile, 0x422910, __stdcall, int, (HANDLE a1))
+
+CLIENT_FUNCTION(ClntObjMgrGetActivePlayer, 0x4D3790, __cdecl, uint64_t, ())
+CLIENT_FUNCTION(ClntObjMgrObjectPtr, 0x4D4DB0, __cdecl, void*, (uint64_t, uint32_t))
+
+CLIENT_FUNCTION(FrameScript_GetText, 0x819D40, __cdecl, char*, (char*, uint32_t, uint32_t))
+CLIENT_FUNCTION(SStrPrintf, 0x76F070, __cdecl, uint32_t, (char*, uint32_t, char*, uint32_t))
+CLIENT_FUNCTION(SStrCopy_0, 0x76EF70, __stdcall, unsigned char, (char*, char*, uint32_t))

--- a/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.cpp
+++ b/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.cpp
@@ -1,13 +1,13 @@
 #include "SpellTooltipExtensions.h"
 #include "windows.h"
 
-void TooltipExtensions::Apply()
+void SpellTooltipExtensions::Apply()
 {
     SpellTooltipRuneCostExtension();
     return;
 }
 
-void TooltipExtensions::SpellTooltipRuneCostExtension() {
+void SpellTooltipExtensions::SpellTooltipRuneCostExtension() {
     DWORD flOldProtect = 0;
     // patched code is stored as an array of literals, deal with it lol
     uint8_t characters[34] = {
@@ -39,7 +39,7 @@ void TooltipExtensions::SpellTooltipRuneCostExtension() {
     return;
 }
 
-void TooltipExtensions::SetRuneCostTooltip(char* dest, char* buff, uint32_t* row, uint32_t* spellFamily) {
+void SpellTooltipExtensions::SetRuneCostTooltip(char* dest, char* buff, uint32_t* row, uint32_t* spellFamily) {
     char* sRuneCost;
     int32_t m_RuneBlood = *(row + 1);
     int32_t m_RuneUnholy = *(row + 2);

--- a/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.cpp
+++ b/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.cpp
@@ -7,14 +7,10 @@ void SpellTooltipExtensions::Apply()
     return;
 }
 
-void SpellTooltipExtensions::SpellTooltipRuneCostExtension() {
-    DWORD flOldProtect = 0;
-    // patched code is stored as an array of literals, deal with it lol
-    uint8_t characters[34] = {
-        0x8D, 0x9D, 0xB8, 0xFD, 0xFF, 0xFF, 0x53, 0x8D, 0x06, 0x50, 0x8D, 0x8D, 0xA0, 0xFE, 0xFF, 0xFF,
-        0x51, 0x8D, 0x95, 0x20, 0xFF, 0xFF, 0xFF, 0x52, 0xE8, 0x00, 0x00, 0x00, 0x00, 0xE9, 0x4B, 0x02,
-        0x00, 0x00
-    };
+// Assembly patch bytes
+constexpr uint8_t PATCH_BYTES[34] = {0x8D, 0x9D, 0xB8, 0xFD, 0xFF, 0xFF, 0x53, 0x8D, 0x06, 0x50, 0x8D, 0x8D,
+                                     0xA0, 0xFE, 0xFF, 0xFF, 0x51, 0x8D, 0x95, 0x20, 0xFF, 0xFF, 0xFF, 0x52,
+                                     0xE8, 0x00, 0x00, 0x00, 0x00, 0xE9, 0x4B, 0x02, 0x00, 0x00};
 
     // patch memory to skip existing code printing rune display and call dll function instead
     // patched code:            // some explainations may not be really correct but whatever
@@ -29,14 +25,17 @@ void SpellTooltipExtensions::SpellTooltipRuneCostExtension() {
     // call function;           // SetRuneCostTooltip(dest, buff, row, spellFamily)
     // jmp loc_623EDE;          // skip remaining code to loc_623EDE
 
-    VirtualProtect((LPVOID)0x623C71, 0x22, PAGE_EXECUTE_READWRITE, &flOldProtect);
-    for (uint8_t i = 0; i < 34; i++)
-        *reinterpret_cast<uint8_t*>(0x623C71 + i) = characters[i];
-    // now write proper address for call function
-    *reinterpret_cast<uint32_t*>(0x623C8A) = (reinterpret_cast<uint32_t>(&SetRuneCostTooltip) - 0x623C8E);
-    VirtualProtect((LPVOID)0x623C71, 0x22, PAGE_EXECUTE_READ, &flOldProtect);
-
-    return;
+void SpellTooltipExtensions::SpellTooltipRuneCostExtension() {
+    DWORD oldProtect;
+    // Change memory protection to allow writing
+    VirtualProtect(reinterpret_cast<void*>( 0x623C71), 0x22, PAGE_EXECUTE_READWRITE, &oldProtect);
+    // Apply the patch bytes
+    std::memcpy(reinterpret_cast<void*>( 0x623C71), PATCH_BYTES, sizeof(PATCH_BYTES));
+    // Calculate and write the relative address for the function call
+    uintptr_t callAddress = reinterpret_cast<uintptr_t>(&SetRuneCostTooltip) - 0x623C8E;
+    *reinterpret_cast<uint32_t*>(0x623C8A) = static_cast<uint32_t>(callAddress);
+    // Restore the original memory protection
+    VirtualProtect(reinterpret_cast<void*>( 0x623C71), 0x22, oldProtect, &oldProtect); 
 }
 
 void SpellTooltipExtensions::SetRuneCostTooltip(char* dest, char* buff, uint32_t* row, uint32_t* spellFamily) {

--- a/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.cpp
+++ b/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.cpp
@@ -44,7 +44,6 @@ void SpellTooltipExtensions::AppendRuneCost(char* runeCostKey, int runeCount, ch
 }
 
 void SpellTooltipExtensions::SetRuneCostTooltip(char* dest, char* buff, uint32_t* row, uint32_t* spellFamily) {
-    char* sRuneCost;
     int32_t m_RuneBlood = *(row + 1);
     int32_t m_RuneUnholy = *(row + 2);
     int32_t m_RuneFrost  = *(row + 3);

--- a/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.h
+++ b/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.h
@@ -6,5 +6,12 @@ private:
     static void Apply();
     static void SetRuneCostTooltip(char* dest, char* buff, uint32_t* row, uint32_t* spellFamily);
     static void SpellTooltipRuneCostExtension();
+    static void AppendRuneCost(char* runeCostKey, int runeCount, char* buff, char* destBuffer);
     friend class ClientExtensions;
+};
+
+struct RuneData
+{
+    char* costKey;
+    int count;
 };

--- a/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.h
+++ b/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "TooltipDefines.h"
 
-class TooltipExtensions {
+class SpellTooltipExtensions {
 private:
     static void Apply();
     static void SetRuneCostTooltip(char* dest, char* buff, uint32_t* row, uint32_t* spellFamily);

--- a/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.h
+++ b/misc/client-extensions/ClientExtensions/Tooltip/SpellTooltipExtensions.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "TooltipDefines.h"
+
+class TooltipExtensions {
+private:
+    static void Apply();
+    static void SetRuneCostTooltip(char* dest, char* buff, uint32_t* row, uint32_t* spellFamily);
+    static void SpellTooltipRuneCostExtension();
+    friend class ClientExtensions;
+};

--- a/misc/client-extensions/ClientExtensions/Tooltip/TooltipDefines.h
+++ b/misc/client-extensions/ClientExtensions/Tooltip/TooltipDefines.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "SharedDefines.h"
+#include <iostream>
+


### PR DESCRIPTION
Something people may find pretty useful (esp. considering the fact recently some people were working on custom classes utilizing dk runes). So, in short, it is based on code I've written as a client patch for Duskhaven (full asm converted to literals so it was pretty hard to modify) and recently ported to Dusk's fork of tswow. It utilizes RUNE_COST_[name] strings from GlobalStrings.lua (or whatever that file is called) but can probably just hardcode them directly in the code.

May require some testing, the code in a bit different version was tested on Dusk's fork.