### PR TITLE
Lua extension: GetSpellDescription

### DIFF
--- a/misc/client-extensions/ClientExtensions/CMakeLists.txt
+++ b/misc/client-extensions/ClientExtensions/CMakeLists.txt
@@ -49,6 +49,7 @@ SET(CLIENT_EXTENSIONS_CPP
     ClientMPQ.cpp
     ClientExtensions.cpp
     Characters/CharacterFixes.cpp
+    CustomLua/SpellFunctions.cpp
     Tooltip/SpellTooltipExtensions.cpp
 )
 

--- a/misc/client-extensions/ClientExtensions/ClientLua.h
+++ b/misc/client-extensions/ClientExtensions/ClientLua.h
@@ -21,6 +21,8 @@ namespace ClientLua {
     CLIENT_FUNCTION(PushNumber, 0x0084E2A0, __cdecl, int, (lua_State* L, double value))
     CLIENT_FUNCTION(PushString, 0x0084E350, __cdecl, int, (lua_State* L, char const* value))
 
+    CLIENT_FUNCTION(PushNil, 0x84E280, __cdecl, int, (lua_State* L))
+
     std::string GetString(lua_State* L, int32_t offset, std::string const& defValue = "");
     double GetNumber(lua_State* L, int32_t offset, double defValue = 0);
 }

--- a/misc/client-extensions/ClientExtensions/CustomLua/SpellFunctions.cpp
+++ b/misc/client-extensions/ClientExtensions/CustomLua/SpellFunctions.cpp
@@ -1,0 +1,20 @@
+#include "ClientLua.h"
+#include "SharedDefines.h"
+
+LUA_FUNCTION(GetSpellDescription, (lua_State* L)) {
+
+    if (ClientLua::IsNumber(L, 1)) {
+        uint32_t spellId = ClientLua::GetNumber(L, 1);
+        char buffer[680];
+        char dest[1024];
+
+        if (ClientDB__GetLocalizedRow((void*)0xAD49D0, spellId, &buffer)) { // hex address is g_SpellRec struct
+            SpellParserParseText(&buffer, &dest, 1024, 0, 0, 0, 0, 1, 0);
+            ClientLua::PushString(L, dest);
+            return 1;
+        }
+    }
+
+    ClientLua::PushNil(L);
+    return 1;
+}

--- a/misc/client-extensions/ClientExtensions/SharedDefines.h
+++ b/misc/client-extensions/ClientExtensions/SharedDefines.h
@@ -38,3 +38,7 @@ CLIENT_FUNCTION(ClntObjMgrObjectPtr, 0x4D4DB0, __cdecl, void*, (uint64_t, uint32
 CLIENT_FUNCTION(FrameScript_GetText, 0x819D40, __cdecl, char*, (char*, uint32_t, uint32_t))
 CLIENT_FUNCTION(SStrPrintf, 0x76F070, __cdecl, uint32_t, (char*, uint32_t, char*, uint32_t))
 CLIENT_FUNCTION(SStrCopy_0, 0x76EF70, __stdcall, unsigned char, (char*, char*, uint32_t))
+
+CLIENT_FUNCTION(ClientDB__GetLocalizedRow, 0x4CFD20, __thiscall, int, (void*, uint32_t, void*))
+
+CLIENT_FUNCTION(SpellParserParseText, 0x57ABC0, __cdecl, void, (void*, void*, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t))

--- a/misc/install-config/include-addon/global.d.ts
+++ b/misc/install-config/include-addon/global.d.ts
@@ -56,6 +56,9 @@ declare function __TS__New(target: any): any;
 declare function base64_decode(str: string): string;
 declare function base64_encode(str: string): string;
 
+// dll additions
+declare function GetSpellDescription(spellID: number): string;
+
 /**
  * Returns the highest expansion id the current account has been flagged for.
  */


### PR DESCRIPTION
The thing guys at blizz figured would be useful around Cataclysm and was added in 4.0.1. Probably requires more testing.
In short, feed it spell id, it prints description field which normally required some workarounds.