### PR TITLE
GameTooltip should extend Frame

### DIFF
--- a/misc/install-config/include-addon/global.d.ts
+++ b/misc/install-config/include-addon/global.d.ts
@@ -12009,7 +12009,7 @@ declare function GetRealmName(): string;
 /// <reference path="../auction.d.ts" />
 
 declare namespace WoWAPI {
-    interface GameTooltip extends UIObject, GameTooltipHookScript, GameTooltipSetScript {
+    interface GameTooltip extends UIObject, Frame, GameTooltipHookScript, GameTooltipSetScript {
 
         /**
          * Adds Line to tooltip with textLeft on left side of line and textRight on right side


### PR DESCRIPTION
GameTooltip should extend Frame, see https://wowpedia.fandom.com/wiki/UIOBJECT_GameTooltip