### PR TITLE
Added string format functions

### DIFF
--- a/misc/install-config/include-addon/global.d.ts
+++ b/misc/install-config/include-addon/global.d.ts
@@ -14006,7 +14006,12 @@ declare const UISpecialFrames: string[];
 declare function loadstring(code: string, name?: string): ()=>void;
 declare function assert(code: ()=>void):() => string;
 declare function type(thing: any): string;
-declare function tonumber(value: string|number, radix?:number): number
+declare function tonumber(value: string|number, radix?:number): number;
+declare function format(pattern: string, ...any:any): string;
+
+interface String {
+    format(...any:any): string;
+};
 
  /**
   * global strings


### PR DESCRIPTION
Needed because TypeScript itself doesn't offer a similar string format function.
It's a basic Lua function but currently not available in TSWoW: https://wowpedia.fandom.com/wiki/API_format

Added the following string format functions:
`format(pattern, ...);`
`stringInstance.format(...);`

Example usage:
`console.log(format(TOOLTIP_TALENT_RANK, 0, 1));`
`console.log(TOOLTIP_TALENT_RANK.format(0, 1));`

I couldn't find a clean way to also add `string.format(pattern, ...);` but i don't think it's really needed.
