### PR TITLE
performance: fix event callback copy

### DIFF
--- a/tswow-core/Public/TSEvent.h
+++ b/tswow-core/Public/TSEvent.h
@@ -176,12 +176,12 @@ private:
 
 #define FIRE(category,name,...)\
 		{\
-				for(auto cb : ts_events.category.name##_callbacks.m_cxx_callbacks)\
+				for(auto const& cb : ts_events.category.name##_callbacks.m_cxx_callbacks)\
 				{\
 						cb(__VA_ARGS__);\
 				}\
 				\
-				for(auto cb : ts_events.category.name##_callbacks.m_lua_callbacks)\
+				for(auto const& cb : ts_events.category.name##_callbacks.m_lua_callbacks)\
 				{\
 						TSLua::handle_error(cb(__VA_ARGS__));\
 				}\
@@ -190,18 +190,18 @@ private:
 #define FIRE_ID(ref,category,name,...)\
 		{\
 				FIRE(category,name,__VA_ARGS__)\
-				auto cxx_cbs = ts_events.category.name##_callbacks.m_id_cxx_callbacks;\
+				auto const& cxx_cbs = ts_events.category.name##_callbacks.m_id_cxx_callbacks;\
 				if(ref < cxx_cbs.size())\
 				{\
-						for(auto cb: cxx_cbs[ref])\
+						for(auto const& cb: cxx_cbs[ref])\
 						{\
 								cb(__VA_ARGS__);\
 						}\
 				}\
-				auto lua_cbs = ts_events.category.name##_callbacks.m_id_lua_callbacks;\
+				auto const& lua_cbs = ts_events.category.name##_callbacks.m_id_lua_callbacks;\
 				if(ref < lua_cbs.size())\
 				{\
-						for(auto cb: lua_cbs[ref])\
+						for(auto const& cb: lua_cbs[ref])\
 						{\
 								try\
 								{\


### PR DESCRIPTION
fixes constant copy of callback function container on each event or hook fire

```

6.44%  worldserver  libgame.so                                   [.] std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > >* std::__do_uninit_copy<__gnu_cxx::__normal_iterator<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > > const*, std::vector<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > >, std::allocator<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > > > > >, std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > >*>(__gnu_cxx::__normal_iterator<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > > const*, std::vector<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > >, std::allocator<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > > > > >, __gnu_cxx::__normal_iterator<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > > const*, std::vector<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > >, std::allocator<std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > > > > >, std::vector<std::function<void (TSCreature, TSUnit)>, std::allocator<std::function<void (TSCreature, TSUnit)> > >*)

```

on perf this was top 1 in my recent profiling runs