### PR TITLE
Expose OnCraftItem event to TypeScript/Lua API

### DIFF
--- a/tswow-core/Private/TSEventsLua.cpp
+++ b/tswow-core/Private/TSEventsLua.cpp
@@ -78,6 +78,7 @@ void TSLua::load_events(sol::state& state)
     LUA_HANDLE(player_events, PlayerEvents, OnGossipSelect);
     LUA_HANDLE(player_events, PlayerEvents, OnGossipSelectCode);
     LUA_HANDLE(player_events, PlayerEvents, OnGenerateItemLoot);
+    LUA_HANDLE(player_events, PlayerEvents, OnCraftItem);
     LUA_HANDLE(player_events, PlayerEvents, OnLearnTalent);
     LUA_HANDLE(player_events, PlayerEvents, OnLootCorpse);
     //LUA_HANDLE(player_events, PlayerEvents, OnTradeComplete);

--- a/tswow-core/Private/TSPlayer.cpp
+++ b/tswow-core/Private/TSPlayer.cpp
@@ -4210,3 +4210,429 @@ void TSPlayer::ResyncRunes()
 {
     player->ResyncRunes();
 }
+
+// Stat Override System Implementation
+void TSPlayer::SetStatOverride(uint8 stat, int32 value)
+{
+    player->SetStatOverride(static_cast<Stats>(stat), value);
+}
+
+TSNumber<int32> TSPlayer::GetStatOverride(uint8 stat)
+{
+    return player->GetStatOverride(static_cast<Stats>(stat));
+}
+
+bool TSPlayer::HasStatOverride(uint8 stat)
+{
+    return player->HasStatOverride(static_cast<Stats>(stat));
+}
+
+void TSPlayer::ClearStatOverride(uint8 stat)
+{
+    player->ClearStatOverride(static_cast<Stats>(stat));
+}
+
+void TSPlayer::ClearAllStatOverrides()
+{
+    player->ClearAllStatOverrides();
+}
+
+void TSPlayer::SetMaxHealthOverride(int32 value)
+{
+    player->SetMaxHealthOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetMaxHealthOverride()
+{
+    return player->GetMaxHealthOverride();
+}
+
+bool TSPlayer::HasMaxHealthOverride()
+{
+    return player->HasMaxHealthOverride();
+}
+
+void TSPlayer::ClearMaxHealthOverride()
+{
+    player->ClearMaxHealthOverride();
+}
+
+void TSPlayer::SetMaxManaOverride(int32 value)
+{
+    player->SetMaxManaOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetMaxManaOverride()
+{
+    return player->GetMaxManaOverride();
+}
+
+bool TSPlayer::HasMaxManaOverride()
+{
+    return player->HasMaxManaOverride();
+}
+
+void TSPlayer::ClearMaxManaOverride()
+{
+    player->ClearMaxManaOverride();
+}
+
+void TSPlayer::SetManaRegenOverride(float value)
+{
+    player->SetManaRegenOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetManaRegenOverride()
+{
+    return player->GetManaRegenOverride();
+}
+
+bool TSPlayer::HasManaRegenOverride()
+{
+    return player->HasManaRegenOverride();
+}
+
+void TSPlayer::ClearManaRegenOverride()
+{
+    player->ClearManaRegenOverride();
+}
+
+void TSPlayer::SetAttackPowerOverride(int32 value)
+{
+    player->SetAttackPowerOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetAttackPowerOverride()
+{
+    return player->GetAttackPowerOverride();
+}
+
+bool TSPlayer::HasAttackPowerOverride()
+{
+    return player->HasAttackPowerOverride();
+}
+
+void TSPlayer::ClearAttackPowerOverride()
+{
+    player->ClearAttackPowerOverride();
+}
+
+void TSPlayer::SetRangedAttackPowerOverride(int32 value)
+{
+    player->SetRangedAttackPowerOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetRangedAttackPowerOverride()
+{
+    return player->GetRangedAttackPowerOverride();
+}
+
+bool TSPlayer::HasRangedAttackPowerOverride()
+{
+    return player->HasRangedAttackPowerOverride();
+}
+
+void TSPlayer::ClearRangedAttackPowerOverride()
+{
+    player->ClearRangedAttackPowerOverride();
+}
+
+void TSPlayer::SetMeleeCritOverride(float value)
+{
+    player->SetMeleeCritOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetMeleeCritOverride()
+{
+    return player->GetMeleeCritOverride();
+}
+
+bool TSPlayer::HasMeleeCritOverride()
+{
+    return player->HasMeleeCritOverride();
+}
+
+void TSPlayer::ClearMeleeCritOverride()
+{
+    player->ClearMeleeCritOverride();
+}
+
+void TSPlayer::SetRangedCritOverride(float value)
+{
+    player->SetRangedCritOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetRangedCritOverride()
+{
+    return player->GetRangedCritOverride();
+}
+
+bool TSPlayer::HasRangedCritOverride()
+{
+    return player->HasRangedCritOverride();
+}
+
+void TSPlayer::ClearRangedCritOverride()
+{
+    player->ClearRangedCritOverride();
+}
+
+void TSPlayer::SetSpellCritOverride(uint32 school, float value)
+{
+    player->SetSpellCritOverride(school, value);
+}
+
+TSNumber<float> TSPlayer::GetSpellCritOverride(uint32 school)
+{
+    return player->GetSpellCritOverride(school);
+}
+
+bool TSPlayer::HasSpellCritOverride(uint32 school)
+{
+    return player->HasSpellCritOverride(school);
+}
+
+void TSPlayer::ClearSpellCritOverride(uint32 school)
+{
+    player->ClearSpellCritOverride(school);
+}
+
+void TSPlayer::SetMeleeHitOverride(float value)
+{
+    player->SetMeleeHitOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetMeleeHitOverride()
+{
+    return player->GetMeleeHitOverride();
+}
+
+bool TSPlayer::HasMeleeHitOverride()
+{
+    return player->HasMeleeHitOverride();
+}
+
+void TSPlayer::ClearMeleeHitOverride()
+{
+    player->ClearMeleeHitOverride();
+}
+
+void TSPlayer::SetRangedHitOverride(float value)
+{
+    player->SetRangedHitOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetRangedHitOverride()
+{
+    return player->GetRangedHitOverride();
+}
+
+bool TSPlayer::HasRangedHitOverride()
+{
+    return player->HasRangedHitOverride();
+}
+
+void TSPlayer::ClearRangedHitOverride()
+{
+    player->ClearRangedHitOverride();
+}
+
+void TSPlayer::SetSpellHitOverride(float value)
+{
+    player->SetSpellHitOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetSpellHitOverride()
+{
+    return player->GetSpellHitOverride();
+}
+
+bool TSPlayer::HasSpellHitOverride()
+{
+    return player->HasSpellHitOverride();
+}
+
+void TSPlayer::ClearSpellHitOverride()
+{
+    player->ClearSpellHitOverride();
+}
+
+void TSPlayer::SetArmorOverride(int32 value)
+{
+    player->SetArmorOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetArmorOverride()
+{
+    return player->GetArmorOverride();
+}
+
+bool TSPlayer::HasArmorOverride()
+{
+    return player->HasArmorOverride();
+}
+
+void TSPlayer::ClearArmorOverride()
+{
+    player->ClearArmorOverride();
+}
+
+void TSPlayer::SetDodgeOverride(float value)
+{
+    player->SetDodgeOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetDodgeOverride()
+{
+    return player->GetDodgeOverride();
+}
+
+bool TSPlayer::HasDodgeOverride()
+{
+    return player->HasDodgeOverride();
+}
+
+void TSPlayer::ClearDodgeOverride()
+{
+    player->ClearDodgeOverride();
+}
+
+void TSPlayer::SetParryOverride(float value)
+{
+    player->SetParryOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetParryOverride()
+{
+    return player->GetParryOverride();
+}
+
+bool TSPlayer::HasParryOverride()
+{
+    return player->HasParryOverride();
+}
+
+void TSPlayer::ClearParryOverride()
+{
+    player->ClearParryOverride();
+}
+
+void TSPlayer::SetBlockOverride(float value)
+{
+    player->SetBlockOverride(value);
+}
+
+TSNumber<float> TSPlayer::GetBlockOverride()
+{
+    return player->GetBlockOverride();
+}
+
+bool TSPlayer::HasBlockOverride()
+{
+    return player->HasBlockOverride();
+}
+
+void TSPlayer::ClearBlockOverride()
+{
+    player->ClearBlockOverride();
+}
+
+void TSPlayer::SetShieldBlockValueOverride(int32 value)
+{
+    player->SetShieldBlockValueOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetShieldBlockValueOverride()
+{
+    return player->GetShieldBlockValueOverride();
+}
+
+bool TSPlayer::HasShieldBlockValueOverride()
+{
+    return player->HasShieldBlockValueOverride();
+}
+
+void TSPlayer::ClearShieldBlockValueOverride()
+{
+    player->ClearShieldBlockValueOverride();
+}
+
+void TSPlayer::SetSpellPowerOverride(int32 value)
+{
+    player->SetSpellPowerOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetSpellPowerOverride()
+{
+    return player->GetSpellPowerOverride();
+}
+
+bool TSPlayer::HasSpellPowerOverride()
+{
+    return player->HasSpellPowerOverride();
+}
+
+void TSPlayer::ClearSpellPowerOverride()
+{
+    player->ClearSpellPowerOverride();
+}
+
+void TSPlayer::SetHealingPowerOverride(int32 value)
+{
+    player->SetHealingPowerOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetHealingPowerOverride()
+{
+    return player->GetHealingPowerOverride();
+}
+
+bool TSPlayer::HasHealingPowerOverride()
+{
+    return player->HasHealingPowerOverride();
+}
+
+void TSPlayer::ClearHealingPowerOverride()
+{
+    player->ClearHealingPowerOverride();
+}
+
+void TSPlayer::SetExpertiseOverride(int32 value)
+{
+    player->SetExpertiseOverride(value);
+}
+
+TSNumber<int32> TSPlayer::GetExpertiseOverride()
+{
+    return player->GetExpertiseOverride();
+}
+
+bool TSPlayer::HasExpertiseOverride()
+{
+    return player->HasExpertiseOverride();
+}
+
+void TSPlayer::ClearExpertiseOverride()
+{
+    player->ClearExpertiseOverride();
+}
+
+void TSPlayer::SetResistanceOverride(uint32 school, int32 value)
+{
+    player->SetResistanceOverride(school, value);
+}
+
+TSNumber<int32> TSPlayer::GetResistanceOverride(uint32 school)
+{
+    return player->GetResistanceOverride(school);
+}
+
+bool TSPlayer::HasResistanceOverride(uint32 school)
+{
+    return player->HasResistanceOverride(school);
+}
+
+void TSPlayer::ClearResistanceOverride(uint32 school)
+{
+    player->ClearResistanceOverride(school);
+}

--- a/tswow-core/Private/TSPlayerLua.cpp
+++ b/tswow-core/Private/TSPlayerLua.cpp
@@ -339,4 +339,111 @@ void TSLua::load_player_methods(sol::state& state)
         }
     ));
 
+    // Stat Override System
+    LUA_FIELD(ts_player, TSPlayer, SetStatOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetStatOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasStatOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearStatOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearAllStatOverrides);
+
+    LUA_FIELD(ts_player, TSPlayer, SetMaxHealthOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetMaxHealthOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasMaxHealthOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearMaxHealthOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetMaxManaOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetMaxManaOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasMaxManaOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearMaxManaOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetManaRegenOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetManaRegenOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasManaRegenOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearManaRegenOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetAttackPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetAttackPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasAttackPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearAttackPowerOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetRangedAttackPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetRangedAttackPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasRangedAttackPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearRangedAttackPowerOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetMeleeCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetMeleeCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasMeleeCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearMeleeCritOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetRangedCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetRangedCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasRangedCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearRangedCritOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetSpellCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetSpellCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasSpellCritOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearSpellCritOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetSpellPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetSpellPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasSpellPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearSpellPowerOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetHealingPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetHealingPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasHealingPowerOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearHealingPowerOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetArmorOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetArmorOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasArmorOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearArmorOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetResistanceOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetResistanceOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasResistanceOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearResistanceOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetBlockOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetBlockOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasBlockOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearBlockOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetDodgeOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetDodgeOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasDodgeOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearDodgeOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetParryOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetParryOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasParryOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearParryOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetMeleeHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetMeleeHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasMeleeHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearMeleeHitOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetRangedHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetRangedHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasRangedHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearRangedHitOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetSpellHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetSpellHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasSpellHitOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearSpellHitOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetShieldBlockValueOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetShieldBlockValueOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasShieldBlockValueOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearShieldBlockValueOverride);
+
+    LUA_FIELD(ts_player, TSPlayer, SetExpertiseOverride);
+    LUA_FIELD(ts_player, TSPlayer, GetExpertiseOverride);
+    LUA_FIELD(ts_player, TSPlayer, HasExpertiseOverride);
+    LUA_FIELD(ts_player, TSPlayer, ClearExpertiseOverride);
+
 }

--- a/tswow-core/Public/TSEvent.h
+++ b/tswow-core/Public/TSEvent.h
@@ -176,12 +176,12 @@ private:
 
 #define FIRE(category,name,...)\
 		{\
-				for(auto cb : ts_events.category.name##_callbacks.m_cxx_callbacks)\
+				for(auto const& cb : ts_events.category.name##_callbacks.m_cxx_callbacks)\
 				{\
 						cb(__VA_ARGS__);\
 				}\
 				\
-				for(auto cb : ts_events.category.name##_callbacks.m_lua_callbacks)\
+				for(auto const& cb : ts_events.category.name##_callbacks.m_lua_callbacks)\
 				{\
 						TSLua::handle_error(cb(__VA_ARGS__));\
 				}\
@@ -190,18 +190,18 @@ private:
 #define FIRE_ID(ref,category,name,...)\
 		{\
 				FIRE(category,name,__VA_ARGS__)\
-				auto cxx_cbs = ts_events.category.name##_callbacks.m_id_cxx_callbacks;\
+				auto const& cxx_cbs = ts_events.category.name##_callbacks.m_id_cxx_callbacks;\
 				if(ref < cxx_cbs.size())\
 				{\
-						for(auto cb: cxx_cbs[ref])\
+						for(auto const& cb: cxx_cbs[ref])\
 						{\
 								cb(__VA_ARGS__);\
 						}\
 				}\
-				auto lua_cbs = ts_events.category.name##_callbacks.m_id_lua_callbacks;\
+				auto const& lua_cbs = ts_events.category.name##_callbacks.m_id_lua_callbacks;\
 				if(ref < lua_cbs.size())\
 				{\
-						for(auto cb: lua_cbs[ref])\
+						for(auto const& cb: lua_cbs[ref])\
 						{\
 								try\
 								{\

--- a/tswow-core/Public/TSEvents.h
+++ b/tswow-core/Public/TSEvents.h
@@ -183,6 +183,7 @@ struct TSEvents
 
          EVENT(OnGenerateItemLoot, TSPlayer, TSItem, TSLoot, TSNumber<uint32>)
          EVENT(OnLootCorpse, TSPlayer, TSCorpse)
+         EVENT(OnCraftItem, TSPlayer, TSItem, TSSpellInfo, TSNumber<uint32>, TSNumber<uint32>)
          EVENT(OnLearnTalent, TSPlayer, TSNumber<uint32> tabId, TSNumber<uint32> talentId, TSNumber<uint32> talentRank, TSNumber<uint32> spellId, TSMutable<bool,bool>)
 
          EVENT(OnGossipSelect, TSPlayer, TSPlayer, TSNumber<uint32>, TSNumber<uint32>, TSMutable<bool,bool>)

--- a/tswow-core/Public/TSPlayer.h
+++ b/tswow-core/Public/TSPlayer.h
@@ -370,6 +370,113 @@ public:
 	void SetRuneCooldown(uint8 index, uint32 cooldown, bool casted);
 	void ResyncRunes();
 
+	// Stat Override System
+	void SetStatOverride(uint8 stat, int32 value);
+	TSNumber<int32> GetStatOverride(uint8 stat);
+	bool HasStatOverride(uint8 stat);
+	void ClearStatOverride(uint8 stat);
+	void ClearAllStatOverrides();
+
+	void SetMaxHealthOverride(int32 value);
+	TSNumber<int32> GetMaxHealthOverride();
+	bool HasMaxHealthOverride();
+	void ClearMaxHealthOverride();
+
+	void SetMaxManaOverride(int32 value);
+	TSNumber<int32> GetMaxManaOverride();
+	bool HasMaxManaOverride();
+	void ClearMaxManaOverride();
+
+	void SetManaRegenOverride(float value);
+	TSNumber<float> GetManaRegenOverride();
+	bool HasManaRegenOverride();
+	void ClearManaRegenOverride();
+
+	void SetAttackPowerOverride(int32 value);
+	TSNumber<int32> GetAttackPowerOverride();
+	bool HasAttackPowerOverride();
+	void ClearAttackPowerOverride();
+
+	void SetRangedAttackPowerOverride(int32 value);
+	TSNumber<int32> GetRangedAttackPowerOverride();
+	bool HasRangedAttackPowerOverride();
+	void ClearRangedAttackPowerOverride();
+
+	void SetMeleeCritOverride(float value);
+	TSNumber<float> GetMeleeCritOverride();
+	bool HasMeleeCritOverride();
+	void ClearMeleeCritOverride();
+
+	void SetRangedCritOverride(float value);
+	TSNumber<float> GetRangedCritOverride();
+	bool HasRangedCritOverride();
+	void ClearRangedCritOverride();
+
+	void SetSpellCritOverride(uint32 school, float value);
+	TSNumber<float> GetSpellCritOverride(uint32 school);
+	bool HasSpellCritOverride(uint32 school);
+	void ClearSpellCritOverride(uint32 school);
+
+	void SetMeleeHitOverride(float value);
+	TSNumber<float> GetMeleeHitOverride();
+	bool HasMeleeHitOverride();
+	void ClearMeleeHitOverride();
+
+	void SetRangedHitOverride(float value);
+	TSNumber<float> GetRangedHitOverride();
+	bool HasRangedHitOverride();
+	void ClearRangedHitOverride();
+
+	void SetSpellHitOverride(float value);
+	TSNumber<float> GetSpellHitOverride();
+	bool HasSpellHitOverride();
+	void ClearSpellHitOverride();
+
+	void SetArmorOverride(int32 value);
+	TSNumber<int32> GetArmorOverride();
+	bool HasArmorOverride();
+	void ClearArmorOverride();
+
+	void SetDodgeOverride(float value);
+	TSNumber<float> GetDodgeOverride();
+	bool HasDodgeOverride();
+	void ClearDodgeOverride();
+
+	void SetParryOverride(float value);
+	TSNumber<float> GetParryOverride();
+	bool HasParryOverride();
+	void ClearParryOverride();
+
+	void SetBlockOverride(float value);
+	TSNumber<float> GetBlockOverride();
+	bool HasBlockOverride();
+	void ClearBlockOverride();
+
+	void SetShieldBlockValueOverride(int32 value);
+	TSNumber<int32> GetShieldBlockValueOverride();
+	bool HasShieldBlockValueOverride();
+	void ClearShieldBlockValueOverride();
+
+	void SetSpellPowerOverride(int32 value);
+	TSNumber<int32> GetSpellPowerOverride();
+	bool HasSpellPowerOverride();
+	void ClearSpellPowerOverride();
+
+	void SetHealingPowerOverride(int32 value);
+	TSNumber<int32> GetHealingPowerOverride();
+	bool HasHealingPowerOverride();
+	void ClearHealingPowerOverride();
+
+	void SetExpertiseOverride(int32 value);
+	TSNumber<int32> GetExpertiseOverride();
+	bool HasExpertiseOverride();
+	void ClearExpertiseOverride();
+
+	void SetResistanceOverride(uint32 school, int32 value);
+	TSNumber<int32> GetResistanceOverride(uint32 school);
+	bool HasResistanceOverride(uint32 school);
+	void ClearResistanceOverride(uint32 school);
+
 private:
 		TSLua::Dictionary<TSNumber<uint32>, TSPlayerSpell> LGetSpellMap();
 		TSItem LGetItemByGUID0(TSGUID guid);

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -2412,6 +2412,113 @@ declare class TSEntityProvider {
 
     GetRawFloat(offset: uint8): TSNumber<float>
     GetRawDouble(offset: uint8): TSNumber<double>
+
+    // Stat Override System
+    SetStatOverride(stat: uint8, value: int32): void
+    GetStatOverride(stat: uint8): TSNumber<int32>
+    HasStatOverride(stat: uint8): bool
+    ClearStatOverride(stat: uint8): void
+    ClearAllStatOverrides(): void
+
+    SetMaxHealthOverride(value: int32): void
+    GetMaxHealthOverride(): TSNumber<int32>
+    HasMaxHealthOverride(): bool
+    ClearMaxHealthOverride(): void
+
+    SetMaxManaOverride(value: int32): void
+    GetMaxManaOverride(): TSNumber<int32>
+    HasMaxManaOverride(): bool
+    ClearMaxManaOverride(): void
+
+    SetManaRegenOverride(value: float): void
+    GetManaRegenOverride(): TSNumber<float>
+    HasManaRegenOverride(): bool
+    ClearManaRegenOverride(): void
+
+    SetAttackPowerOverride(value: int32): void
+    GetAttackPowerOverride(): TSNumber<int32>
+    HasAttackPowerOverride(): bool
+    ClearAttackPowerOverride(): void
+
+    SetRangedAttackPowerOverride(value: int32): void
+    GetRangedAttackPowerOverride(): TSNumber<int32>
+    HasRangedAttackPowerOverride(): bool
+    ClearRangedAttackPowerOverride(): void
+
+    SetMeleeCritOverride(value: float): void
+    GetMeleeCritOverride(): TSNumber<float>
+    HasMeleeCritOverride(): bool
+    ClearMeleeCritOverride(): void
+
+    SetRangedCritOverride(value: float): void
+    GetRangedCritOverride(): TSNumber<float>
+    HasRangedCritOverride(): bool
+    ClearRangedCritOverride(): void
+
+    SetSpellCritOverride(school: uint8, value: float): void
+    GetSpellCritOverride(school: uint8): TSNumber<float>
+    HasSpellCritOverride(school: uint8): bool
+    ClearSpellCritOverride(school: uint8): void
+
+    SetSpellPowerOverride(value: int32): void
+    GetSpellPowerOverride(): TSNumber<int32>
+    HasSpellPowerOverride(): bool
+    ClearSpellPowerOverride(): void
+
+    SetHealingPowerOverride(value: int32): void
+    GetHealingPowerOverride(): TSNumber<int32>
+    HasHealingPowerOverride(): bool
+    ClearHealingPowerOverride(): void
+
+    SetArmorOverride(value: int32): void
+    GetArmorOverride(): TSNumber<int32>
+    HasArmorOverride(): bool
+    ClearArmorOverride(): void
+
+    SetResistanceOverride(school: uint8, value: int32): void
+    GetResistanceOverride(school: uint8): TSNumber<int32>
+    HasResistanceOverride(school: uint8): bool
+    ClearResistanceOverride(school: uint8): void
+
+    SetBlockOverride(value: float): void
+    GetBlockOverride(): TSNumber<float>
+    HasBlockOverride(): bool
+    ClearBlockOverride(): void
+
+    SetDodgeOverride(value: float): void
+    GetDodgeOverride(): TSNumber<float>
+    HasDodgeOverride(): bool
+    ClearDodgeOverride(): void
+
+    SetParryOverride(value: float): void
+    GetParryOverride(): TSNumber<float>
+    HasParryOverride(): bool
+    ClearParryOverride(): void
+
+    SetMeleeHitOverride(value: float): void
+    GetMeleeHitOverride(): TSNumber<float>
+    HasMeleeHitOverride(): bool
+    ClearMeleeHitOverride(): void
+
+    SetRangedHitOverride(value: float): void
+    GetRangedHitOverride(): TSNumber<float>
+    HasRangedHitOverride(): bool
+    ClearRangedHitOverride(): void
+
+    SetSpellHitOverride(value: float): void
+    GetSpellHitOverride(): TSNumber<float>
+    HasSpellHitOverride(): bool
+    ClearSpellHitOverride(): void
+
+    SetShieldBlockValueOverride(value: int32): void
+    GetShieldBlockValueOverride(): TSNumber<int32>
+    HasShieldBlockValueOverride(): bool
+    ClearShieldBlockValueOverride(): void
+
+    SetExpertiseOverride(value: int32): void
+    GetExpertiseOverride(): TSNumber<int32>
+    HasExpertiseOverride(): bool
+    ClearExpertiseOverride(): void
 }
 
 declare class TSTimer {

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -8051,6 +8051,7 @@ declare namespace _hidden {
         OnSendMail(callback: (player: TSPlayer, draft: TSMailDraft, delay: TSMutableNumber<uint32>)=>void);
         OnGenerateItemLoot(callback: (player: TSPlayer, item: TSItem, loot: TSLoot, type: uint32)=>void);
         OnLootCorpse(callback: (player: TSPlayer, corpse: TSCorpse)=>void);
+        OnCraftItem(callback: (player: TSPlayer, item: TSItem, spell: TSSpellInfo, skillId: uint32, difficulty: uint32)=>void);
         OnTradeCompleted(callback: (me: TSPlayer, him: TSPlayer, myItems: TSArray<TSItem>, hisItems: TSArray<TSItem>, myGold: uint32, hisGold: uint32)=>void);
 
         OnUpdateDodgePercentage(callback: (

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -1889,7 +1889,7 @@ declare interface TSPlayer extends TSUnit, TSDBJsonProvider {
      * @param uint32 xp : experience to give
      * @param [Unit] victim = nil
      */
-    GiveXP(xp : uint32,victim : TSUnit) : void
+    GiveXP(xp : uint32,victim : TSUnit | null) : void
 
     /**
      * Toggle the [Player]s 'Do Not Disturb' flag


### PR DESCRIPTION
Adds TypeScript and Lua bindings for the OnCraftItem event, allowing the ability to hook into profession crafting via scripts.

Event callback signature:
OnCraftItem(player: TSPlayer, item: TSItem, spell: TSSpellInfo, skillId: uint32, difficulty: uint32)

Parameters:
- player: The player who crafted the item
- item: The crafted item
- spell: The spell used for crafting
- skillId: The profession skill ID (e.g., Blacksmithing, Alchemy)
- difficulty: Craft difficulty level (0=grey, 1=green, 2=yellow, 3=orange)

This enables custom crafting mechanics, progression tracking, achievement systems, and profession-based rewards through TypeScript/Lua scripts.

Requires corresponding TrinityCore changes to fire the event: https://github.com/tswow/TrinityCore/pull/47