### PR TITLE
Add facial style methods to global definitions

### DIFF
--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -2612,6 +2612,9 @@ declare interface TSOutfit {
     SetHairColor(color: uint8): TSOutfit;
     GetHairColor(): TSNumber<uint8>;
 
+    SetFacialStyle(facialStyle: uint8): TSOutfit;
+    GetFacialStyle(): TSNumber<uint8>;
+
     SetSoundID(soundId: uint32): TSOutfit;
     GetSoundID(): TSNumber<uint32>
 


### PR DESCRIPTION
These methods were already implemented but just not exposed. While there are similar methods on the TSPlayer class, exposing them on the TSOutfit class allows developers to change the facial style on any TSOutfit, regardless of whether they are appleid to a TSPlayer, TSCreature, etc.