### PR TITLE
Fix parameter order in TSLoot::AddItem

### DIFF
--- a/tswow-core/Private/TSLoot.cpp
+++ b/tswow-core/Private/TSLoot.cpp
@@ -48,7 +48,7 @@ void TSLoot::AddItem(uint32 id, uint8 minCount, uint8 maxCount, uint16 lootmode,
 {
     loot->items.reserve(MAX_NR_LOOT_ITEMS);
     loot->quest_items.reserve(MAX_NR_QUEST_ITEMS);
-    loot->AddItem(LootStoreItem(id,0,100,lootmode,needsQuest,groupId,minCount,maxCount));
+    loot->AddItem(LootStoreItem(id,0,100,needsQuest,lootmode,groupId,minCount,maxCount));
 }
 
 void TSLoot::AddLooter(uint64 looter)


### PR DESCRIPTION
The LootStoreItem constructor expects parameters in this order:
  (itemid, reference, chance, needs_quest, lootmode, groupid, mincount, maxcount)

TSLoot::AddItem was incorrectly passing:
  (id, 0, 100, lootmode, needsQuest, groupId, minCount, maxCount)

Fixed to correctly pass:
  (id, 0, 100, needsQuest, lootmode, groupId, minCount, maxCount)

The lootmode (uint16) and needsQuest (bool) parameters were swapped.