### PR TITLE
Add game_event_arena_seasons SQL table wrapper

### DIFF
--- a/tswow-scripts/wotlk/SQLFiles.ts
+++ b/tswow-scripts/wotlk/SQLFiles.ts
@@ -74,6 +74,7 @@ import { SQL_gameobject_template } from './sql/gameobject_template'
 import { SQL_gameobject_template_addon } from './sql/gameobject_template_addon'
 import { SQL_gameobject_template_locale } from './sql/gameobject_template_locale'
 import { SQL_game_event } from './sql/game_event'
+import { SQL_game_event_arena_seasons } from './sql/game_event_arena_seasons'
 import { SQL_game_event_battleground_holiday } from './sql/game_event_battleground_holiday'
 import { SQL_game_event_condition } from './sql/game_event_condition'
 import { SQL_game_event_creature } from './sql/game_event_creature'
@@ -458,6 +459,11 @@ export const SQL = {
      * No comment (yet!)
      */
     game_event : SQL_game_event,
+
+    /**
+     * No comment (yet!)
+     */
+    game_event_arena_seasons : SQL_game_event_arena_seasons,
 
     /**
      * No comment (yet!)

--- a/tswow-scripts/wotlk/sql/game_event_arena_seasons.ts
+++ b/tswow-scripts/wotlk/sql/game_event_arena_seasons.ts
@@ -1,0 +1,94 @@
+/*
+  * Copyright (C) 2020 tswow <https://github.com/tswow/>
+  * This program is free software: you can redistribute it and/or
+  * modify it under the terms of the GNU General Public License as
+  * published by the Free Software Foundation, version 3.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  * See the GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
+  */
+
+/* tslint:disable */
+import { tinyint } from '../../data/primitives'
+import { Relation } from '../../data/query/Relations'
+import { PrimaryKey } from '../../data/table/PrimaryKey'
+import { SQLCellReadOnly } from '../../data/sql/SQLCell'
+import { SqlRow } from '../../data/sql/SQLRow'
+import { SqlTable } from '../../data/sql/SQLTable'
+
+ /**
+  * Main row definition
+  * - Add column comments to the commented getters below
+  * - Add file comments to DBCFiles.ts
+  */
+export class game_event_arena_seasonsRow extends SqlRow<game_event_arena_seasonsCreator,game_event_arena_seasonsQuery> {
+    /**
+     * Primary Key
+     *
+     * No comment (yet!)
+     */
+    @PrimaryKey()
+    get eventEntry() {return new SQLCellReadOnly<tinyint, this>(this, 'eventEntry')}
+
+    /**
+     * Primary Key
+     *
+     * No comment (yet!)
+     */
+    @PrimaryKey()
+    get season() {return new SQLCellReadOnly<tinyint, this>(this, 'season')}
+
+    /**
+     * Creates a clone of this row with new primary keys.
+     *
+     * Cloned rows are automatically added to the SQL table.
+     */
+    clone(eventEntry : tinyint,season : tinyint, c? : game_event_arena_seasonsCreator) : this {
+        return this.cloneInternal([eventEntry,season],c)
+    }
+}
+
+/**
+ * Used for object creation (Don't comment these)
+ */
+export type game_event_arena_seasonsCreator = {
+    eventEntry? : tinyint,
+    season? : tinyint,
+}
+
+/**
+ * Used for object queries (Don't comment these)
+ */
+export type game_event_arena_seasonsQuery = {
+    eventEntry? : Relation<tinyint>,
+    season? : Relation<tinyint>,
+}
+
+/**
+ * Table definition (specifies arguments to 'add' function)
+ * - Add file comments to SQLFiles.ts
+ */
+export class game_event_arena_seasonsTable extends SqlTable<
+    game_event_arena_seasonsCreator,
+    game_event_arena_seasonsQuery,
+    game_event_arena_seasonsRow> {
+    add(eventEntry : tinyint,season : tinyint, c? : game_event_arena_seasonsCreator) : game_event_arena_seasonsRow {
+        const first = this.first();
+        if(first) return first.clone(eventEntry,season,c)
+        else return this.rowCreator(this, {}).clone(eventEntry,season,c)
+    }
+}
+
+/**
+ * Table singleton (Object used by 'SQL' namespace)
+ * - Add file comments to SQLFiles.ts
+ */
+export const SQL_game_event_arena_seasons = new game_event_arena_seasonsTable(
+    'game_event_arena_seasons',
+    (table, obj)=>new game_event_arena_seasonsRow(table, obj))
+


### PR DESCRIPTION
Examples:

```ts
import { SQL } from "wow/wotlk";

// Link an arena season to a game event
// When arena season 5 starts, it will automatically trigger game event 50
SQL.game_event_arena_seasons.add(50, 5);

// Query all arena seasons linked to a specific game event
const seasonsForEvent = SQL.game_event_arena_seasons.queryAll({ eventEntry: 50 });
seasonsForEvent.forEach(row => {
    console.log(`Event ${row.eventEntry.get()} is linked to arena season ${row.season.get()}`);
});

// Query which game event is linked to a specific arena season
const eventForSeason = SQL.game_event_arena_seasons.query({ season: 5 });
if (eventForSeason) {
    console.log(`Arena season 5 triggers game event ${eventForSeason.eventEntry.get()}`);
}

// Remove a season-event link
const link = SQL.game_event_arena_seasons.query({ eventEntry: 50, season: 5 });
if (link) {
    link.delete();
}
```

https://trinitycore.info/en/database/335/world/game_event_arena_seasons