### PR TITLE
When clearing a Holiday DBC entry, clears all fields

### DIFF
--- a/tswow-scripts/wotlk/std/GameEvent/Holiday.ts
+++ b/tswow-scripts/wotlk/std/GameEvent/Holiday.ts
@@ -99,6 +99,20 @@ export class HolidayRegistryClass
             .Priority.set(0)
             .Texture.set('')
             .Type.set(0)
+        entity.row.Region.set(0)
+        entity.row.Looping.set(0)
+        
+        for (let i = 0; i < 10; i++) {
+            entity.row.Duration.setIndex(i, 0);
+        }
+        
+        for (let i = 0; i < 26; i++) {
+            entity.row.Date.setIndex(i, 0);
+        }
+        
+        for (let i = 0; i < 10; i++) {
+            entity.row.CalendarFlags.setIndex(i, 0);
+        }
     }
     protected FindByID(id: number): HolidaysRow {
         return DBC.Holidays.findById(id);


### PR DESCRIPTION
including Date, Duration, CalendarFlags, Region and Looping.