### PR TITLE
Fix/package listfile path separators

### DIFF
--- a/tswow-scripts/runtime/Package.ts
+++ b/tswow-scripts/runtime/Package.ts
@@ -87,7 +87,7 @@ export class Package {
                         }
                     }
                 }
-                appendListfile('luaxml',`${node.abs().get()}\t${rel}\n`)
+                appendListfile('luaxml',`${node.abs().get()}\t${rel.get().replace(/\//g, '\\')}\n`)
             });
         }
 
@@ -103,7 +103,7 @@ export class Package {
                         || lower.endsWith('.json')
                         || lower.endsWith('.dbc')
                     ) return;
-                    appendListfile(x.fullName, `${node.abs()}\t${node.relativeTo(x.assets.path)}\n`)
+                    appendListfile(x.fullName, `${node.abs()}\t${node.relativeTo(x.assets.path).get().replace(/\//g, '\\')}\n`)
                 });
             })
 
@@ -161,7 +161,7 @@ export class Package {
         }
     }
 
-    static Command = commands.addCommand('package')
+    static Command = commands.addCommand('package', '', 'Packages client and server data for distribution')
 
     static initialize() {
         term.debug('misc', `Initializing packages`)


### PR DESCRIPTION
## Summary
- Convert forward slashes to backslashes in listfile entries
- MPQ archives expect Windows-style paths with backslashes
- Add description to package command

## Changes
- `tswow-scripts/runtime/Package.ts`: Fix path separator in `appendListfile()` calls to use `\` instead of `/`

## Why
When tswow generates listfiles for directory-based MPQ archives on Linux, it was writing paths with forward slashes (`World/maps/...`). The map/vmap extractors expect Windows-style backslash paths (`World\Maps\...`) when looking up files. This fix ensures the listfile entries use the correct format.
