### PR TITLE
Add macOS (OSX) build support

### DIFF
--- a/tswow-core/Private/TSEventsLua.cpp
+++ b/tswow-core/Private/TSEventsLua.cpp
@@ -401,29 +401,29 @@ void TSLua::load_events(sol::state& state)
     LUA_MAPPED_HANDLE(worldpacket_events, WorldPacketEvents, OnReceive);
     LUA_MAPPED_HANDLE(worldpacket_events, WorldPacketEvents, OnSend);
 
-    lua_events["World"] = &TSEvents::World;
-    lua_events["Unit"] = &TSEvents::Unit;
-    lua_events["AuctionHouse"] = &TSEvents::AuctionHouse;
-    lua_events["Vehicle"] = &TSEvents::Vehicle;
-    lua_events["Player"] = &TSEvents::Player;
-    lua_events["Account"] = &TSEvents::Account;
-    lua_events["Guild"] = &TSEvents::Guild;
-    lua_events["Group"] = &TSEvents::Group;
-    lua_events["Spell"] = &TSEvents::Spell;
-    lua_events["Creature"] = &TSEvents::Creature;
-    lua_events["Battleground"] = &TSEvents::Battleground;
-    lua_events["Item"] = &TSEvents::Item;
-    lua_events["Quest"] = &TSEvents::Quest;
+    lua_events["World"] = [](TSEvents& events) -> TSEvents::WorldEvents& { return events.World; };
+    lua_events["Unit"] = [](TSEvents& events) -> TSEvents::UnitEvents& { return events.Unit; };
+    lua_events["AuctionHouse"] = [](TSEvents& events) -> TSEvents::AuctionEvents& { return events.AuctionHouse; };
+    lua_events["Vehicle"] = [](TSEvents& events) -> TSEvents::VehicleEvents& { return events.Vehicle; };
+    lua_events["Player"] = [](TSEvents& events) -> TSEvents::PlayerEvents& { return events.Player; };
+    lua_events["Account"] = [](TSEvents& events) -> TSEvents::AccountEvents& { return events.Account; };
+    lua_events["Guild"] = [](TSEvents& events) -> TSEvents::GuildEvents& { return events.Guild; };
+    lua_events["Group"] = [](TSEvents& events) -> TSEvents::GroupEvents& { return events.Group; };
+    lua_events["Spell"] = [](TSEvents& events) -> TSEvents::SpellEvents& { return events.Spell; };
+    lua_events["Creature"] = [](TSEvents& events) -> TSEvents::CreatureEvents& { return events.Creature; };
+    lua_events["Battleground"] = [](TSEvents& events) -> TSEvents::BattlegroundEvents& { return events.Battleground; };
+    lua_events["Item"] = [](TSEvents& events) -> TSEvents::ItemEvents& { return events.Item; };
+    lua_events["Quest"] = [](TSEvents& events) -> TSEvents::QuestEvents& { return events.Quest; };
 #if TRINITY
-    lua_events["AreaTrigger"] = &TSEvents::AreaTrigger;
+    lua_events["AreaTrigger"] = [](TSEvents& events) -> TSEvents::AreaTriggerEvents& { return events.AreaTrigger; };
 #endif
-    lua_events["Map"] = &TSEvents::Map;
-    lua_events["Instance"] = &TSEvents::Instance;
-    lua_events["Achievement"] = &TSEvents::Achievement;
-    lua_events["GameEvent"] = &TSEvents::GameEvent;
-    lua_events["SmartAction"] = &TSEvents::SmartAction;
-    lua_events["Condition"] = &TSEvents::Condition;
-    lua_events["CustomPacket"] = &TSEvents::CustomPacket;
-    lua_events["WorldPacket"] = &TSEvents::WorldPacket;
-    lua_events["GameObject"] = &TSEvents::GameObject;
+    lua_events["Map"] = [](TSEvents& events) -> TSEvents::MapEvents& { return events.Map; };
+    lua_events["Instance"] = [](TSEvents& events) -> TSEvents::InstanceEvents& { return events.Instance; };
+    lua_events["Achievement"] = [](TSEvents& events) -> TSEvents::AchievementEvents& { return events.Achievement; };
+    lua_events["GameEvent"] = [](TSEvents& events) -> TSEvents::GameEventsEvents& { return events.GameEvent; };
+    lua_events["SmartAction"] = [](TSEvents& events) -> TSEvents::SmartActionEvents& { return events.SmartAction; };
+    lua_events["Condition"] = [](TSEvents& events) -> TSEvents::ConditionEvents& { return events.Condition; };
+    lua_events["CustomPacket"] = [](TSEvents& events) -> TSEvents::CustomPacketEvents& { return events.CustomPacket; };
+    lua_events["WorldPacket"] = [](TSEvents& events) -> TSEvents::WorldPacketEvents& { return events.WorldPacket; };
+    lua_events["GameObject"] = [](TSEvents& events) -> TSEvents::GameObjectEvents& { return events.GameObject; };
 }

--- a/tswow-core/Private/TSPositionLua.cpp
+++ b/tswow-core/Private/TSPositionLua.cpp
@@ -4,11 +4,12 @@
 void TSLua::load_position_methods(sol::state& state)
 {
     auto ts_position = state.new_usertype<TSPosition>("TSPosition");
-    ts_position["x"] = &TSPosition::x;
-    ts_position["y"] = &TSPosition::y;
-    ts_position["z"] = &TSPosition::z;
-    ts_position["o"] = &TSPosition::o;
-    ts_position["map"] = &TSPosition::map;
+    // Use lambdas to wrap member pointers for C++20 compatibility with Clang
+    ts_position["x"] = [](TSPosition& pos) -> TSNumber<float>& { return pos.x; };
+    ts_position["y"] = [](TSPosition& pos) -> TSNumber<float>& { return pos.y; };
+    ts_position["z"] = [](TSPosition& pos) -> TSNumber<float>& { return pos.z; };
+    ts_position["o"] = [](TSPosition& pos) -> TSNumber<float>& { return pos.o; };
+    ts_position["map"] = [](TSPosition& pos) -> uint32& { return pos.map; };
 
     state.set_function("CreatePosition", CreatePosition);
 }

--- a/tswow-scripts/compile/TrinityCore.ts
+++ b/tswow-scripts/compile/TrinityCore.ts
@@ -262,8 +262,9 @@ export namespace TrinityCore {
                 // TODO: Set up optimization flags for o0 as debug and o3 as release
                 setupCommand = `cmake ${relSource}`
                 +` -DCMAKE_INSTALL_PREFIX=${relInstall}`
-                +` -DCMAKE_C_COMPILER=/usr/bin/clang`
-                +` -DCMAKE_CXX_COMPILER=/usr/bin/clang++`
+                +` -DCONF_DIR=${relInstall}/etc`
+                +` -DCMAKE_C_COMPILER=${process.env.CC || '/usr/bin/clang'}`
+                +` -DCMAKE_CXX_COMPILER=${process.env.CXX || '/usr/bin/clang++'}`
                 +` -DBUILD_SHARED_LIBS="ON"`
                 +` -DBUILD_TESTING="OFF"`
                 +` -DTRACY_ENABLED="${Args.hasFlag('tracy',[process.argv,args1])}"`

--- a/tswow-scripts/runtime/Dataset.ts
+++ b/tswow-scripts/runtime/Dataset.ts
@@ -312,6 +312,7 @@ export class Datasets {
 
     all() {
         return this.path.dataset.all()
+            .filter(x => !x.basename().get().startsWith('.'))
             .map(x=>new Dataset(this.mod, x.basename().get()))
     }
 

--- a/tswow-scripts/util/Paths.ts
+++ b/tswow-scripts/util/Paths.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import path from 'path';
 import { mpath, wfs } from './FileSystem';
 import { custom, dir, dirn, dynCustom, dyndir, dynfile, enumDir, file, FilePath, generateTree, WDirectory, WFile } from "./FileTree";
-import { isWindows } from './Platform';
+import { isWindows, isOSX } from './Platform';
 
 export const TDB_URL = "https://github.com/TrinityCore/TrinityCore/releases/download/TDB335.24081/TDB_full_world_335.24081_2024_08_17.7z"
 
@@ -612,6 +612,7 @@ export function BuildPaths(pathIn: string, tdb: string) {
             }),
 
             libraries: custom((pathIn=>(type: string)=>{
+                const libExt = isOSX() ? 'dylib' : 'so';
                 return (isWindows() ?
                 [
                     `dep/zlib/${type}/zlib.lib`,
@@ -631,35 +632,38 @@ export function BuildPaths(pathIn: string, tdb: string) {
                 ]
                 :
                 [
-                    `install/trinitycore/lib/libcommon.so`,
-                    `install/trinitycore/lib/libdatabase.so`,
-                    `install/trinitycore/lib/libgame.so`,
-                    `install/trinitycore/lib/libshared.so`,
-                    `install/trinitycore/lib/libTracyClient.so`,
+                    `install/trinitycore/lib/libcommon.${libExt}`,
+                    `install/trinitycore/lib/libdatabase.${libExt}`,
+                    `install/trinitycore/lib/libgame.${libExt}`,
+                    `install/trinitycore/lib/libshared.${libExt}`,
+                    `install/trinitycore/lib/libTracyClient.${libExt}`,
                 ]
                 ).map(x=>new WFile(mpath(pathIn,x)))
             })),
 
-            libraries2: ((pathIn: string, type: string)=>(isWindows() ?
-            [
-                `dep/zlib/${type}/zlib.lib`,
-                `src/server/shared/${type}/shared.lib`,
-                `dep/SFMT/${type}/sfmt.lib`,
-                `dep/g3dlite/${type}/g3dlib.lib`,
-                `dep/fmt/${type}/fmt.lib`,
-                `dep/recastnavigation/Detour/${type}/detour.lib`,
-                `src/server/database/${type}/database.lib`,
-                `src/server/game/${type}/game.lib`,
-                `src/common/${type}/common.lib`,
-                `dep/argon2/${type}/argon2.lib`
-            ]
-            :
-            [
-                `install/trinitycore/lib/libcommon.so`,
-                `install/trinitycore/lib/libdatabase.so`,
-                `install/trinitycore/lib/libgame.so`,
-                `install/trinitycore/lib/libshared.so`,
-            ]).map(x=>new WFile(pathIn).join(x)))
+            libraries2: ((pathIn: string, type: string)=>{
+                const libExt = isOSX() ? 'dylib' : 'so';
+                return (isWindows() ?
+                [
+                    `dep/zlib/${type}/zlib.lib`,
+                    `src/server/shared/${type}/shared.lib`,
+                    `dep/SFMT/${type}/sfmt.lib`,
+                    `dep/g3dlite/${type}/g3dlib.lib`,
+                    `dep/fmt/${type}/fmt.lib`,
+                    `dep/recastnavigation/Detour/${type}/detour.lib`,
+                    `src/server/database/${type}/database.lib`,
+                    `src/server/game/${type}/game.lib`,
+                    `src/common/${type}/common.lib`,
+                    `dep/argon2/${type}/argon2.lib`
+                ]
+                :
+                [
+                    `install/trinitycore/lib/libcommon.${libExt}`,
+                    `install/trinitycore/lib/libdatabase.${libExt}`,
+                    `install/trinitycore/lib/libgame.${libExt}`,
+                    `install/trinitycore/lib/libshared.${libExt}`,
+                ]).map(x=>new WFile(pathIn).join(x))
+            })
         }),
 
         mpqbuilder: dir({

--- a/tswow-scripts/util/Platform.ts
+++ b/tswow-scripts/util/Platform.ts
@@ -22,6 +22,10 @@ export function isWindows() {
     return process.platform === 'win32';
 }
 
+export function isOSX() {
+    return process.platform === 'darwin';
+}
+
 export function getOS() {
     if (isWindows()) { return 'windows'; }
     // Assume it's linux


### PR DESCRIPTION
- Add isOSX() platform detection function
- Update library paths to use .dylib extension on macOS
- Make compiler paths configurable via CC/CXX environment variables
- Add CONF_DIR to CMake configuration
- Fix C++ member pointer syntax for Clang/C++20 compatibility
- Filter hidden files in dataset directory listing

This enables building tswow on macOS systems.

Resolves https://github.com/tswow/tswow/issues/935 when combined with https://github.com/tswow/TrinityCore/pull/50

Guide on OSX install: https://github.com/suprsokr/tswow-docs/blob/main/osx-setup.md