### PR TITLE
Linux: get the build and a running server/client working on modern Arch

### DIFF
--- a/TSWOW_HANDOFF.md
+++ b/TSWOW_HANDOFF.md
@@ -1,0 +1,157 @@
+# TSWoW on Arch Linux — Session Handoff
+
+**Date:** 2026-06-14
+**Status:** ✅ Build works · ✅ DB works · ⚠️ Full server boot needs WoW 3.3.5a client · ⏳ Portable packaging not done
+
+---
+
+## TL;DR
+
+TSWoW now builds and installs cleanly on Arch (gcc 16.1.1, cmake 4.3.3, boost 1.91, openssl 3.6, mariadb 12.3, node 26). All Arch-specific failures were patched (files listed below — patches live in working tree, **NOT committed**). Running `worldserver` directly succeeds (banner + boost/openssl/MariaDB connection works). The `node start.js server-mode` wrapper completes DB migrations + world.dest rebuild, then hangs waiting on client data (DBC/maps). This is expected without a WoW client.
+
+---
+
+## Toolchain (Arch verified)
+
+- gcc/g++ 16.1.1 · cmake 4.3.3 · boost 1.91 (system) · openssl 3.6.3
+- mariadb 12.3.2 (user `tswow@localhost` / password `password`)
+- node 26.2.0 · npm 11.16.0 · p7zip 26.01
+- Fish shell — no `$!`, use `$last_pid`
+
+---
+
+## Layout
+
+- Source: `~/Documents/sources/tswow/`
+- Build:  `~/Documents/sources/tswow-build/`
+- Install:`~/Documents/sources/tswow-install/` (3.2 GB, working)
+- Mods/launcher: `~/Documents/wowmods/start.sh` (auto-detects client, falls back to server-mode)
+- TC binaries: `tswow-install/bin/trinitycore/RelWithDebInfo/{worldserver,authserver,...}`
+- Realm config: `tswow-install/modules/default/realms/realm/{worldserver.conf,realm.conf}`
+
+---
+
+## Patches applied (all in `~/Documents/sources/tswow/`, uncommitted)
+
+### Build system / toolchain
+- `arch-compat/boost_compat/boost_system-1.91.0/` — **NEW** shim providing `Boost::system` INTERFACE target (boost 1.91 made boost_system header-only and removed cmake config).
+- `tswow-scripts/compile/TrinityCore.ts` (Linux branch ~L256-296): `TSWOW_CC||/usr/bin/gcc`, `TSWOW_CXX||/usr/bin/g++`, `-DCMAKE_PREFIX_PATH=<arch-compat/boost_compat>`, `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`, `-DWITH_WARNINGS=0`, `make -j $(nproc)`.
+- `tswow-scripts/compile/MPQBuilder.ts` + `tswow-scripts/compile/BLPConverter.ts` Linux branches: same gcc + policy + parallel make.
+- `misc/mpqbuilder/CMakeLists.txt` + `misc/blpconverter/CMakeLists.txt`: `set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "" FORCE)` after `cmake_minimum_required` (cmd-line `-D` does not propagate into FetchContent_Populate + add_subdirectory for legacy StormLib `cmake_minimum_required 2.8.12`).
+- `misc/blpconverter/CMakeLists.txt`: also `target_compile_options(... -std=gnu11 -Wno-implicit-function-declaration -Wno-implicit-int -Wno-old-style-definition)` + `target_compile_definitions(... Z_HAVE_UNISTD_H=1 _LARGEFILE64_SOURCE=1)` (bundled zlib/libimagequant use K&R and pre-C99 idioms).
+
+### TrinityCore source
+- `cores/TrinityCore/CMakeLists.txt` ~L36: `target_include_directories(liblua PUBLIC ${LUA_ROOT})` — sol2 PCH must see fetched lua 5.4 not system 5.5.
+- `~/Documents/sources/tswow-build/TrinityCore/_deps/lua-src/lua.hpp` — **NEW** extern-C wrapper so `<lua.hpp>` resolves to fetched 5.4.
+- `cores/TrinityCore/dep/boost/CMakeLists.txt`: removed `-DBOOST_ASIO_NO_DEPRECATED` (deadline_timer.hpp is guarded by it).
+- `cores/TrinityCore/dep/jemalloc/src/jemalloc_cpp.cpp` ~L70: `std::__throw_bad_alloc()` → `throw std::bad_alloc()` (gcc 16 removed helper).
+- `cores/TrinityCore/dep/jemalloc/include/jemalloc/internal/safety_check.h`: `void(*)()` → `void(*)(const char*)`.
+- `cores/TrinityCore/src/common/Utilities/StartProcess.cpp`: all `<boost/process/X.hpp>` → `<boost/process/v1/X.hpp>`, `boost::process` → `boost::process::v1` (boost 1.91 split).
+- `tswow-core/Public/TSPlayer.h` ~L24: `#include "TSItemEntry.h"` — gcc 16 instantiates `vector<TSItemEntry>` dtor for default arg, forward decl no longer enough.
+
+---
+
+## Reproduce build (Arch)
+
+```bash
+sudo pacman -S --needed gcc cmake boost openssl mariadb mariadb-libs nodejs npm \
+  p7zip git python clang ncurses zlib bzip2
+
+# MariaDB (once)
+sudo mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+sudo systemctl enable --now mariadb
+sudo mariadb -e "CREATE USER 'tswow'@'localhost' IDENTIFIED BY 'password'; \
+  GRANT ALL ON *.* TO 'tswow'@'localhost' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+
+cd ~/Documents/sources/tswow
+git submodule update --init --recursive
+npm install
+node build.js          # full pipeline — produces ~/Documents/sources/tswow-install/
+```
+
+---
+
+## Run
+
+```bash
+cd ~/Documents/sources/tswow-install
+node start.js                    # needs Wow.exe + client
+node start.js server-mode        # skips client validation; hangs without data
+# direct worldserver test (verifies build):
+cd modules/default/realms/realm && \
+  ../../../../bin/trinitycore/RelWithDebInfo/worldserver -c worldserver.conf
+```
+
+`~/Documents/wowmods/start.sh` is a wrapper that auto-finds an adjacent WoW 3.3.5a client.
+
+---
+
+## Verification status
+
+| Component | State |
+|---|---|
+| TrinityCore compile + link | ✅ `--version` reports `c797f13b2c9f+ (Unix, RelWithDebInfo, Dynamic)` |
+| mpqbuilder, blpconverter | ✅ built |
+| Install pipeline | ✅ "Installation successful!" |
+| Auth/characters/world.source migrations | ✅ 6+7+25 applied |
+| world.dest rebuild | ✅ runs |
+| worldserver binary runs standalone | ✅ banner + DB connect + boost/openssl OK |
+| Full `node start.js server-mode` to port 8085 bound | ❌ hangs — needs DBC/map data from real client |
+| Login with WoW 3.3.5a client | ⏳ untested (no client on hand) |
+
+---
+
+## NEXT SESSION — pick up here
+
+### 1. End-to-end verification with a real client (priority 1)
+- Place a WoW 3.3.5a client at `~/Documents/wowmods/<anything>/Wow.exe`.
+- Run `~/Documents/wowmods/start.sh`. It will copy/patch `Default.Client` in `node.conf`, extract DBC/maps/vmaps/mmaps (long, one-time), then bring auth (3724) + world (8085) online.
+- Verify ports: `ss -tlnp | grep -E ':3724|:8085'`.
+- Create an account: in tswow prompt `account create <user> <pass>` then `account set gmlevel <user> 3 -1`.
+
+### 2. Portable packaging (user's standing request)
+**Blocker:** TC binaries have `RUNPATH=/home/blin/Documents/sources/tswow-build/TrinityCore/install/trinitycore/lib` baked in. Also link to Arch-specific `libboost_*.so.1.91.0`, `libssl.so.3`, `libmariadb.so.3`.
+
+Three options (user has not yet chosen):
+
+1. **Build script (most portable, smallest):** ship the repo + `setup-arch.sh` / `setup-debian.sh` that installs deps and runs `node build.js`. Reliable across distros.
+2. **Same-distro Arch tarball:** `patchelf --set-rpath '$ORIGIN/../lib' bin/trinitycore/RelWithDebInfo/{worldserver,authserver,*.so,...}`, bundle required `.so`s, ship `tswow-arch-linux.tar.gz` (~500 MB-1 GB) with a `run.sh` setting `LD_LIBRARY_PATH`. Works only on current-ish Arch.
+3. **AppImage:** bundle every dep, single executable. Highest portability, most work.
+
+Recommended starting point: option 2 script:
+```bash
+cd ~/Documents/sources/tswow-install
+find bin -type f \( -executable -o -name '*.so*' \) -exec file {} + \
+  | grep ELF | cut -d: -f1 \
+  | xargs -I{} patchelf --set-rpath '$ORIGIN:$ORIGIN/../lib' {}
+ldd bin/trinitycore/RelWithDebInfo/worldserver  # collect non-glibc deps into ./lib/
+tar czf ~/tswow-arch.tar.gz -C ~/Documents/sources tswow-install
+```
+
+### 3. Commit patches upstream-quality
+All changes are in working tree of `~/Documents/sources/tswow/`. Group as logical commits:
+- "Arch/gcc16 build fixes"
+- "Boost 1.91 compatibility (process v1, system shim, asio deprecated)"
+- "cmake 4 policy minimum"
+- "lua 5.4 isolation from system 5.5"
+- "blpconverter/mpqbuilder C compatibility"
+
+---
+
+## Key lessons / gotchas
+
+- `cmd | tee log | tail -N` **hides** live output (tail flushes at EOF). Use `> log 2>&1 &` and poll separately.
+- `node build.js` swallows cmake nonzero exit then `epoll_wait`s forever (8h hang observed). Always check `/tmp/*.log` and kill node if stuck.
+- cmake `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` does **not** propagate into FetchContent + add_subdirectory. Must edit the parent CMakeLists.txt with `set(... CACHE STRING "" FORCE)` before the fetch.
+- tswow ports: 3724 (auth) · 8085 (world) · 7878 (internal)
+- TC binary RUNPATH check: `readelf -d worldserver | grep -E 'RPATH|RUNPATH'`
+
+---
+
+## Files referenced
+
+- `~/Documents/sources/tswow/` — repo with patches
+- `~/Documents/sources/tswow-build/` — cmake build dir
+- `~/Documents/sources/tswow-install/` — runnable install (3.2 GB)
+- `~/Documents/wowmods/start.sh` — launcher (4.8k, executable)
+- `/memories/build-tips.md` — general lessons (top-level memory only; repo/session scopes unavailable)

--- a/build.default.conf
+++ b/build.default.conf
@@ -1,2 +1,4 @@
 BuildDirectory = "../tswow-build"
 InstallDirectory = "../tswow-install"
+Linux.MakeJobs = 4
+Linux.UseCCache = true

--- a/build.js
+++ b/build.js
@@ -5,6 +5,147 @@ const child_process = require('child_process');
 const path = require('path');
 const fs = require('fs')
 
+/**
+ * On Linux/macOS, verify the system build prerequisites *before* we run any
+ * `npm i` (which compiles native modules like deasync and needs a C toolchain
+ * and python). This must live in build.js — the plain-JS entry point — because
+ * the compiled TypeScript build scripts can't run until `npm i` has succeeded.
+ *
+ * We never install anything automatically unless the user explicitly opts in
+ * with `--install-deps`, since that needs root and is potentially destructive.
+ */
+function checkLinuxPrerequisites() {
+    if (process.platform === 'win32') { return; }
+
+    const has = (cmd) => {
+        try {
+            child_process.execSync(`command -v ${cmd}`, { stdio: 'ignore' });
+            return true;
+        } catch (e) { return false; }
+    };
+    const hasBoost = () =>
+           fs.existsSync('/usr/include/boost/version.hpp')
+        || fs.existsSync('/usr/local/include/boost/version.hpp');
+
+    const pm =
+          has('pacman')  ? 'pacman'
+        : has('apt-get') ? 'apt'
+        : has('dnf')     ? 'dnf'
+        : has('zypper')  ? 'zypper'
+        : 'unknown';
+
+    // Each requirement maps to a package name per supported package manager.
+    const reqs = [
+        { name: 'C/C++ toolchain + make + python (gcc/g++, for TrinityCore and native npm modules)',
+          ok: (has('gcc') || has('cc')) && (has('g++') || has('c++') || has('clang++')) && has('make') && (has('python3') || has('python')),
+          pkg: { pacman:'base-devel python', apt:'build-essential python3', dnf:'@development-tools python3', zypper:'-t pattern devel_basis python3' } },
+        { name: 'CMake', ok: has('cmake'),
+          pkg: { pacman:'cmake', apt:'cmake', dnf:'cmake', zypper:'cmake' } },
+        { name: 'Git', ok: has('git'),
+          pkg: { pacman:'git', apt:'git', dnf:'git', zypper:'git' } },
+        { name: 'Boost (headers + libraries)', ok: hasBoost(),
+          pkg: { pacman:'boost', apt:'libboost-all-dev', dnf:'boost-devel', zypper:'boost-devel' } },
+        { name: 'OpenSSL', ok: has('openssl'),
+          pkg: { pacman:'openssl', apt:'libssl-dev', dnf:'openssl-devel', zypper:'libopenssl-devel' } },
+        { name: 'MySQL/MariaDB server + client',
+          ok: (has('mariadbd') || has('mysqld')) && (has('mariadb') || has('mysql')),
+          pkg: { pacman:'mariadb', apt:'mariadb-server default-libmysqlclient-dev', dnf:'mariadb-server mariadb-connector-c-devel', zypper:'mariadb mariadb-client libmariadb-devel' } },
+        { name: '7-Zip (extract world database)',
+          ok: has('7za') || has('7z') || has('7zr'),
+          pkg: { pacman:'p7zip', apt:'p7zip-full', dnf:'p7zip', zypper:'p7zip' } },
+    ];
+    // Optional: warn only.
+    const optional = [
+        { name: 'ccache (optional, speeds up rebuilds)', ok: has('ccache'),
+          pkg: { pacman:'ccache', apt:'ccache', dnf:'ccache', zypper:'ccache' } },
+        { name: 'Wine (optional, to run the game client)', ok: has('wine') || has('wine64'),
+          pkg: { pacman:'wine', apt:'wine', dnf:'wine', zypper:'wine' } },
+    ];
+
+    for (const o of optional) {
+        if (!o.ok) { console.log(`[tswow] Optional dependency missing: ${o.name}`); }
+    }
+
+    const missing = reqs.filter(r => !r.ok);
+    if (missing.length === 0) { return; }
+
+    const installCmd = (() => {
+        const pkgs = missing.map(m => m.pkg[pm]).filter(Boolean).join(' ');
+        switch (pm) {
+            case 'pacman': return `sudo pacman -S --needed ${pkgs}`;
+            case 'apt':    return `sudo apt-get update && sudo apt-get install -y ${pkgs}`;
+            case 'dnf':    return `sudo dnf install -y ${pkgs}`;
+            case 'zypper': return `sudo zypper install -y ${pkgs}`;
+            default:       return null;
+        }
+    })();
+
+    // Non-interactive variant used only for --install-deps (so the build can run
+    // fully unattended). The printed command above stays interactive so users who
+    // run it by hand can review what will be installed.
+    const installCmdNonInteractive = (() => {
+        const pkgs = missing.map(m => m.pkg[pm]).filter(Boolean).join(' ');
+        switch (pm) {
+            case 'pacman': return `sudo pacman -S --needed --noconfirm ${pkgs}`;
+            case 'apt':    return `sudo apt-get update && sudo apt-get install -y ${pkgs}`;
+            case 'dnf':    return `sudo dnf install -y ${pkgs}`;
+            case 'zypper': return `sudo zypper install -y --no-confirm ${pkgs}`;
+            default:       return null;
+        }
+    })();
+
+    console.error('\n[tswow] Missing required build dependencies:');
+    for (const m of missing) { console.error(`  - ${m.name}`); }
+
+    const wantsInstall = process.argv.includes('--install-deps');
+    if (wantsInstall && installCmdNonInteractive) {
+        console.log(`\n[tswow] Installing missing dependencies:\n    ${installCmdNonInteractive}\n`);
+        try {
+            child_process.execSync(installCmdNonInteractive, { stdio: 'inherit' });
+        } catch (e) {
+            console.error(`\n[tswow] Automatic install failed. Please run it manually:\n    ${installCmd}\n`);
+            process.exit(1);
+        }
+        return;
+    }
+
+    if (installCmd) {
+        console.error(
+              `\n[tswow] TSWoW needs some system packages that aren't installed yet.`
+            + `\n[tswow] Install them with your package manager:\n`
+            + `\n    ${installCmd}\n`
+            + `\n[tswow] Then run the build again.`
+            + ` (Or re-run with --install-deps to let TSWoW run the command above for you.)\n`
+        );
+    } else {
+        console.error(
+              `\n[tswow] TSWoW needs the packages listed above, but your package`
+            + ` manager could not be detected. Please install them manually,`
+            + ` then run the build again.\n`
+        );
+    }
+    process.exit(1);
+}
+
+checkLinuxPrerequisites();
+
+// The TrinityCore core lives in a git submodule. If the user cloned without
+// --recursive it will be empty and the build fails cryptically later, so check
+// for it here and tell them exactly how to fix it.
+function checkSubmodules() {
+    const coreCMake = path.join('cores', 'TrinityCore', 'CMakeLists.txt');
+    if (!fs.existsSync(coreCMake)) {
+        console.error(
+              `\n[tswow] The TrinityCore submodule is missing (cores/TrinityCore is empty).`
+            + `\n[tswow] Fetch it with:\n`
+            + `\n    git submodule update --init --recursive\n`
+            + `\n[tswow] Then run the build again.\n`
+        );
+        process.exit(1);
+    }
+}
+checkSubmodules();
+
 if(!fs.existsSync('./build.conf')) {
     fs.copyFileSync('./build.default.conf','./build.conf');
 }
@@ -15,6 +156,16 @@ const buildDir = buildConf.match(/^BuildDirectory *= *"(.+?)"/m)[1]
 const installDir = buildConf.match(/^InstallDirectory *= *"(.+?)"/m)[1]
 const displayNames = (buildConf.match(/^Terminal\.DisplayNames *= *(.+)/m)||['','true'])[1]
 const displayTimestamps = (buildConf.match(/^Terminal\.DisplayTimestamps *= *(.+)/m)||['','true'])[1]
+const linuxMakeJobsRaw = (buildConf.match(/^Linux\.MakeJobs *= *(.+)/m)||['','8'])[1]
+const linuxUseCCacheRaw = (buildConf.match(/^Linux\.UseCCache *= *(.+)/m)||['','true'])[1]
+
+const parsedLinuxMakeJobs = Number(String(linuxMakeJobsRaw).trim().replace(/^"|"$/g,''))
+const linuxMakeJobs = Number.isFinite(parsedLinuxMakeJobs) && parsedLinuxMakeJobs > 0
+    ? parsedLinuxMakeJobs
+    : 8
+const linuxUseCCache = ['true','1','yes','on'].includes(
+    String(linuxUseCCacheRaw).trim().replace(/^"|"$/g,'').toLowerCase()
+)
 
 const shouldDisplayNames = displayNames === 'true'
     || displayNames === '1'
@@ -33,8 +184,13 @@ catch(error) {
     child_process.execSync('npm i')
     try { buildScripts() }
     catch(error) {
-        console.log(`Failed to bootstrap tswow: ${error}`);
-        process.exit(0)
+        console.error(
+              `\n[tswow] Failed to bootstrap the build scripts: ${error}`
+            + `\n[tswow] This usually means 'npm i' could not finish. Common causes:`
+            + `\n  - Missing C toolchain/python for native modules (run with --install-deps)`
+            + `\n  - A broken node_modules; try removing it and re-running.\n`
+        );
+        process.exit(1)
     }
 }
 child_process.execSync('npx swc --version', {stdio:'inherit'})
@@ -53,4 +209,8 @@ child_process.execSync(
     + ` --bpaths=${buildDir}`
     + ` ${shouldDisplayNames?'--displayNames':''}`
     + ` ${shouldDisplayTimestamps?'--displayTimestamps':''}`
-,{stdio:'inherit'});
+,{stdio:'inherit', env: {
+      ...process.env
+    , TSWOW_LINUX_MAKE_JOBS: String(linuxMakeJobs)
+    , TSWOW_LINUX_USE_CCACHE: linuxUseCCache ? '1' : '0'
+}});

--- a/cmake/linux/boost_system_fallback/README.txt
+++ b/cmake/linux/boost_system_fallback/README.txt
@@ -1,0 +1,17 @@
+Boost::system fallback for distros without per-component config
+
+This directory holds a tiny CMake "config package" that synthesises a
+Boost::system / boost_system INTERFACE target. It exists because, starting
+with Boost 1.87, boost_system was made header-only and a few Linux distros
+stopped shipping boost_system-<version>/boost_system-config.cmake even though
+the rest of the Boost CMake configs are present. TrinityCore still uses
+find_package(Boost ... COMPONENTS system), which then fails to locate the
+target.
+
+The Linux branch of tswow-scripts/compile/TrinityCore.ts adds this directory
+to CMAKE_PREFIX_PATH when configuring the TrinityCore subproject. If the
+real boost_system config is found first (older Boost, or distros that still
+package it), this fallback is never loaded.
+
+If/when TrinityCore grows an inline fallback for the same situation in
+dep/boost/CMakeLists.txt, this directory can be removed.

--- a/cmake/linux/boost_system_fallback/boost_system-config-version.cmake
+++ b/cmake/linux/boost_system_fallback/boost_system-config-version.cmake
@@ -1,0 +1,11 @@
+# The fallback claims to satisfy any requested version; we are only loaded
+# when the real boost_system config is missing on the system, and Boost is
+# already resolved by Boost::headers at this point.
+if(DEFINED PACKAGE_FIND_VERSION AND NOT "${PACKAGE_FIND_VERSION}" STREQUAL "")
+  set(PACKAGE_VERSION "${PACKAGE_FIND_VERSION}")
+else()
+  set(PACKAGE_VERSION "1.87.0")
+endif()
+set(PACKAGE_VERSION_COMPATIBLE TRUE)
+set(PACKAGE_VERSION_EXACT TRUE)
+set(PACKAGE_VERSION_UNSUITABLE FALSE)

--- a/cmake/linux/boost_system_fallback/boost_system-config.cmake
+++ b/cmake/linux/boost_system_fallback/boost_system-config.cmake
@@ -1,0 +1,42 @@
+# Synthetic Boost::system / boost_system target for distros that ship Boost
+# without a per-component config file.
+#
+# Starting with Boost 1.87 boost_system was made header-only. Several distros
+# (notably Arch, but also some other rolling-release setups) stopped shipping
+# boost_system-<version>/boost_system-config.cmake as a result, while the
+# rest of Boost's CMake configs are still installed. TrinityCore still calls
+# find_package(Boost ... COMPONENTS system) and then fails to locate the
+# target, even though everything that boost_system used to provide is now in
+# Boost::headers.
+#
+# When the parent build adds this directory to CMAKE_PREFIX_PATH and
+# find_package(boost_system CONFIG) is invoked, this file is picked up and
+# creates an INTERFACE IMPORTED target that re-exports Boost::headers, which
+# matches what the modern boost_system component does in practice.
+#
+# If/when TrinityCore grows an inline fallback for this in
+# dep/boost/CMakeLists.txt, this directory can be removed.
+
+if(TARGET Boost::system)
+  set(boost_system_FOUND TRUE)
+  return()
+endif()
+
+if(NOT TARGET Boost::headers)
+  find_package(boost_headers CONFIG REQUIRED)
+endif()
+
+add_library(Boost::system INTERFACE IMPORTED)
+set_target_properties(Boost::system PROPERTIES
+  INTERFACE_LINK_LIBRARIES "Boost::headers"
+  INTERFACE_COMPILE_DEFINITIONS "BOOST_SYSTEM_NO_DEPRECATED;BOOST_ALL_NO_LIB"
+)
+
+if(NOT TARGET boost_system)
+  add_library(boost_system INTERFACE IMPORTED)
+  set_target_properties(boost_system PROPERTIES
+    INTERFACE_LINK_LIBRARIES "Boost::headers"
+  )
+endif()
+
+set(boost_system_FOUND TRUE)

--- a/misc/blpconverter/CMakeLists.txt
+++ b/misc/blpconverter/CMakeLists.txt
@@ -1,8 +1,21 @@
 cmake_minimum_required (VERSION 3.22)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "" FORCE)
 project (BLPConverter)
 file(GLOB_RECURSE sources *.cpp *.hpp *.c *.h)
 add_executable (blpconverter main.cpp ${sources})
 set_target_properties(blpconverter PROPERTIES CXX_STANDARD 17)
+# Bundled zlib/libpng/libimagequant use K&R-style declarations and POSIX
+# functions without including <unistd.h>. GCC 16 / C23 rejects both as
+# errors. Pin them to gnu89 + downgrade implicit-decl + define
+# Z_HAVE_UNISTD_H so zlib pulls in unistd.h.
+set_source_files_properties(${sources} PROPERTIES LANGUAGE_DEPENDENT_COMPILE_DEFINITIONS "")
+target_compile_definitions(blpconverter PRIVATE Z_HAVE_UNISTD_H=1 _LARGEFILE64_SOURCE=1)
+target_compile_options(blpconverter PRIVATE
+	$<$<COMPILE_LANGUAGE:C>:-std=gnu11>
+	$<$<COMPILE_LANGUAGE:C>:-Wno-implicit-function-declaration>
+	$<$<COMPILE_LANGUAGE:C>:-Wno-implicit-int>
+	$<$<COMPILE_LANGUAGE:C>:-Wno-old-style-definition>
+)
 target_include_directories(blpconverter PUBLIC
 	blp2png
 	png2blp

--- a/misc/mpqbuilder/CMakeLists.txt
+++ b/misc/mpqbuilder/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "" FORCE)
 project(mpqbuilder)
 set( Boost_USE_STATIC_LIBS ON )
 FIND_PACKAGE( Boost 1.60 COMPONENTS filesystem REQUIRED )

--- a/misc/mpqbuilder/luaxmlreader.cpp
+++ b/misc/mpqbuilder/luaxmlreader.cpp
@@ -117,6 +117,11 @@ int main(int argc, char **argv) {
 	}
 
 	for (auto& patch : patches) {
+		// Skip patches that aren't present in this client (e.g. an optional
+		// patch-3.MPQ). A missing optional patch shouldn't abort extraction.
+		if (!fs::exists(patch)) {
+			continue;
+		}
 		if (!SFileOpenPatchArchive(mpq, patch.string().c_str(), NULL, 0)) {
 			std::cout << "Failed to apply patch " << patch << " with error " << GetLastError() << "\n";
 			return GetLastError();

--- a/tswow-core/Public/TSPlayer.h
+++ b/tswow-core/Public/TSPlayer.h
@@ -22,6 +22,11 @@
 #include "TSUnit.h"
 #include "TSOutfit.h"
 #include "TSDBJson.h"
+// GCC 16 instantiates the std::vector<TSItemEntry> destructor when this header
+// is parsed (because TSArray<TSItemEntry>() appears as a default argument
+// below), so the full definition is required here rather than only the
+// forward declaration further down the file.
+#include "TSItemEntry.h"
 
 #include <sol/sol.hpp>
 

--- a/tswow-scripts/compile/BLPConverter.ts
+++ b/tswow-scripts/compile/BLPConverter.ts
@@ -33,12 +33,18 @@ export namespace BLPConverter {
             bpaths.blpconverter.mkdir()
             const relativeBlpConverterSource = bpaths.blpconverter
                 .relativeFrom(spaths.misc.blpconverter.get());
+            const cc = process.env.TSWOW_CC || '/usr/bin/gcc';
+            const cxx = process.env.TSWOW_CXX || '/usr/bin/g++';
+            const jobs = require('os').cpus().length;
             await wsys.inDirectory(bpaths.blpconverter.get()
                 , () => {
                     wsys.exec(
                         `${cmake} "${relativeBlpConverterSource}"`
+                        + ` -DCMAKE_C_COMPILER=${cc}`
+                        + ` -DCMAKE_CXX_COMPILER=${cxx}`
+                        + ` -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
                         ,  'inherit');
-                    wsys.exec(`make`,'inherit');
+                    wsys.exec(`make -j ${jobs}`,'inherit');
                 });
         }
         bpaths.blpconverter.blpconverter_exe.copy(ipaths.bin.BLPConverter.blpconverter)

--- a/tswow-scripts/compile/Config.ts
+++ b/tswow-scripts/compile/Config.ts
@@ -68,7 +68,7 @@ export namespace Config {
 
         // Serverside lua includes
         spaths.misc.install_config.include_lua.copy(bpaths.include_lua),
-        wsys.execIn(bpaths.include_lua,'tstl')
+        wsys.execIn(bpaths.include_lua,'npx tstl')
         bpaths.include_lua.iterate('RECURSE','FILES','FULL', node => {
             if(['.ts','.json'].find(x=>node.endsWith(x))) {
                 return;
@@ -97,7 +97,7 @@ export namespace Config {
                 "noImplicitSelf": true,
             }
         })
-        wsys.execIn(bpaths.lua_events, 'tstl')
+        wsys.execIn(bpaths.lua_events, 'npx tstl')
         bpaths.lua_events.events_lua.copy(
             ipaths.bin.include_addon.Events_lua)
         bpaths.lua_events.lualib_bundle.copy(
@@ -160,11 +160,19 @@ export namespace Config {
         TrinityCore.headers(false);
         spaths.misc.install_config.snippet_example.copy(ipaths.vscode.snippets_out)
 
-        let commit = wsys.exec('git rev-parse HEAD','pipe').split('\n').join('');
-        let h = wsys.exec('git status --porcelain')
-            .split(' ').join('')
-            .split('\n').join('')
-            .split('\r').join('');
+        // Revision stamping is best-effort: builds from a ZIP/tarball download
+        // (no .git) or without git installed should still succeed.
+        let commit = 'unknown';
+        let h = '';
+        try {
+            commit = wsys.exec('git rev-parse HEAD','pipe').split('\n').join('');
+            h = wsys.exec('git status --porcelain')
+                .split(' ').join('')
+                .split('\n').join('')
+                .split('\r').join('');
+        } catch (err) {
+            term.warn('build','Could not read git revision (not a git checkout?); using "unknown".')
+        }
 
         ipaths.bin.revisions.tswow.write(`${commit}${h.length>0?'+':''}`)
 

--- a/tswow-scripts/compile/MPQBuilder.ts
+++ b/tswow-scripts/compile/MPQBuilder.ts
@@ -33,12 +33,18 @@ export namespace MPQBuilder {
         } else {
             bpaths.mpqbuilder.mkdir()
             const relativeMpqSource = bpaths.mpqbuilder.relativeFrom(spaths.misc.mpqbuilder.get());
+            const cc = process.env.TSWOW_CC || '/usr/bin/gcc';
+            const cxx = process.env.TSWOW_CXX || '/usr/bin/g++';
+            const jobs = require('os').cpus().length;
             await wsys.inDirectory(bpaths.mpqbuilder.get()
                 , () => {
                     wsys.exec(
                         `${cmake} "${relativeMpqSource}"`
+                        + ` -DCMAKE_C_COMPILER=${cc}`
+                        + ` -DCMAKE_CXX_COMPILER=${cxx}`
+                        + ` -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
                         ,  'inherit');
-                    wsys.exec(`make`,'inherit');
+                    wsys.exec(`make -j ${jobs}`,'inherit');
                 });
         }
         bpaths.mpqbuilder.mpqbuilder_exe.copy(ipaths.bin.mpqbuilder.mpqbuilder_exe)

--- a/tswow-scripts/compile/Scripts.ts
+++ b/tswow-scripts/compile/Scripts.ts
@@ -48,7 +48,7 @@ export namespace Scripts {
             )
 
             if(!isInteractive) {
-                wsys.execIn(buildDir,'tsc','inherit')
+                wsys.execIn(buildDir,'npx tsc','inherit')
             } else {
                 watchTsc(
                       'node'

--- a/tswow-scripts/compile/TrinityCore.ts
+++ b/tswow-scripts/compile/TrinityCore.ts
@@ -259,18 +259,34 @@ export namespace TrinityCore {
                     .relativeFrom(spaths.cores.TrinityCore)
                 const relInstall = bpaths.TrinityCore
                     .relativeFrom(bpaths.TrinityCore.join('install','trinitycore'))
+                // Compiler selection: env-driven, with a gcc default. Modern
+                // clang (>= 18 or so) refuses to build TrinityCore when
+                // WITH_WARNINGS is enabled, so gcc is a safer baseline for
+                // Linux users; anyone preferring clang can still set
+                // TSWOW_CC / TSWOW_CXX.
+                const ccDefault = '/usr/bin/gcc'
+                const cxxDefault = '/usr/bin/g++'
+                const cc = process.env.TSWOW_CC || ccDefault
+                const cxx = process.env.TSWOW_CXX || cxxDefault
+                // Boost::system fallback for distros that ship Boost without
+                // a per-component boost_system config (see
+                // cmake/linux/boost_system_fallback/README.txt).
+                const boostSystemFallback = require('path').resolve(
+                    process.cwd(),'cmake','linux','boost_system_fallback')
                 // TODO: Set up optimization flags for o0 as debug and o3 as release
                 setupCommand = `cmake ${relSource}`
                 +` -DCMAKE_INSTALL_PREFIX=${relInstall}`
-                +` -DCMAKE_C_COMPILER=/usr/bin/clang`
-                +` -DCMAKE_CXX_COMPILER=/usr/bin/clang++`
+                +` -DCMAKE_C_COMPILER=${cc}`
+                +` -DCMAKE_CXX_COMPILER=${cxx}`
+                +` -DCMAKE_PREFIX_PATH="${boostSystemFallback}"`
+                +` -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
                 +` -DBUILD_SHARED_LIBS="ON"`
                 +` -DBUILD_TESTING="OFF"`
                 +` -DTRACY_ENABLED="${Args.hasFlag('tracy',[process.argv,args1])}"`
                 +` -DTRACY_TIMER_FALLBACK="${!Args.hasFlag('tracy-timer-fallback',[process.argv,args1])?'ON':'OFF'}"`
-                +` -DWITH_WARNINGS=1`
+                +` -DWITH_WARNINGS=0`
                 +` -DSCRIPTS=${scripts}`;
-                buildCommand = 'make -j 4';
+                buildCommand = `make -j ${require('os').cpus().length}`;
                 await bpaths.TrinityCore.doIn(() => {
                     wsys.exec(setupCommand, 'inherit');
                     if(generateOnly) return;

--- a/tswow-scripts/compile/TrinityCore.ts
+++ b/tswow-scripts/compile/TrinityCore.ts
@@ -273,6 +273,18 @@ export namespace TrinityCore {
                 // cmake/linux/boost_system_fallback/README.txt).
                 const boostSystemFallback = require('path').resolve(
                     process.cwd(),'cmake','linux','boost_system_fallback')
+                // Parallel build jobs, overridable via build.conf (Linux.MakeJobs).
+                const parsedMakeJobs = Number(process.env.TSWOW_LINUX_MAKE_JOBS || '0');
+                const makeJobs = Number.isFinite(parsedMakeJobs) && parsedMakeJobs > 0
+                    ? parsedMakeJobs
+                    : require('os').cpus().length;
+                // Optional ccache to speed up repeat builds; opt out with
+                // Linux.UseCCache=false in build.conf.
+                const enableCcache = (process.env.TSWOW_LINUX_USE_CCACHE || '1') !== '0';
+                let ccacheArgs = '';
+                if (enableCcache && wsys.hasCommand('ccache')) {
+                    ccacheArgs = ' -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache';
+                }
                 // TODO: Set up optimization flags for o0 as debug and o3 as release
                 setupCommand = `cmake ${relSource}`
                 +` -DCMAKE_INSTALL_PREFIX=${relInstall}`
@@ -280,13 +292,15 @@ export namespace TrinityCore {
                 +` -DCMAKE_CXX_COMPILER=${cxx}`
                 +` -DCMAKE_PREFIX_PATH="${boostSystemFallback}"`
                 +` -DCMAKE_POLICY_VERSION_MINIMUM=3.5`
+                +`${ccacheArgs}`
                 +` -DBUILD_SHARED_LIBS="ON"`
                 +` -DBUILD_TESTING="OFF"`
+                +` -DNOJEM=1`
                 +` -DTRACY_ENABLED="${Args.hasFlag('tracy',[process.argv,args1])}"`
                 +` -DTRACY_TIMER_FALLBACK="${!Args.hasFlag('tracy-timer-fallback',[process.argv,args1])?'ON':'OFF'}"`
                 +` -DWITH_WARNINGS=0`
                 +` -DSCRIPTS=${scripts}`;
-                buildCommand = `make -j ${require('os').cpus().length}`;
+                buildCommand = `make -j ${makeJobs}`;
                 await bpaths.TrinityCore.doIn(() => {
                     wsys.exec(setupCommand, 'inherit');
                     if(generateOnly) return;
@@ -336,9 +350,16 @@ export namespace TrinityCore {
         // Move ts-module header files
         headers(false);
 
-        const rev = wsys.execIn(
-              spaths.cores.TrinityCore.get()
-            , 'git rev-parse HEAD','pipe').split('\n').join('');
+        // Best-effort revision stamp: don't fail the build if this isn't a git
+        // checkout (e.g. a ZIP/tarball download) or git isn't installed.
+        let rev = 'unknown';
+        try {
+            rev = wsys.execIn(
+                  spaths.cores.TrinityCore.get()
+                , 'git rev-parse HEAD','pipe').split('\n').join('');
+        } catch (err) {
+            term.warn('build','Could not read TrinityCore git revision; using "unknown".')
+        }
         ipaths.bin.revisions.trinitycore.write(rev)
 
         term.log('build','Copying sql patches')

--- a/tswow-scripts/runtime/Client.ts
+++ b/tswow-scripts/runtime/Client.ts
@@ -15,6 +15,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import { sleep } from 'deasync';
 import { Args } from '../util/Args';
 import { ClientPatches, EXTENSION_DLL_PATCH_NAME } from '../util/ClientPatches';
@@ -23,6 +24,7 @@ import { WDirectory, WNode } from '../util/FileTree';
 import { ClientPath, ipaths } from '../util/Paths';
 import { isWindows } from '../util/Platform';
 import { Process } from '../util/Process';
+import { wsys } from '../util/System';
 import { term } from '../util/Terminal';
 import { StartCommand } from './CommandActions';
 import { Dataset } from './Dataset';
@@ -32,6 +34,40 @@ import { NodeConfig } from './NodeConfig';
 export const CLEAN_CLIENT_MD5 = '45892bdedd0ad70aed4ccd22d9fb5984'
 
 const processMap: {[datasetName: string]: Process[]} = {}
+
+/**
+ * Absolute path to the dedicated wine prefix tswow uses for the client on
+ * Linux/macOS. Keeping the client in its own prefix means we can shut its wine
+ * session down (wineserver -k) without affecting any other wine apps.
+ */
+function winePrefix(): string {
+    return ipaths.coredata.join('wine').abs().get();
+}
+
+/**
+ * Environment for launching the wine client: an isolated prefix, and mono/gecko
+ * install prompts disabled so startup is non-interactive.
+ */
+function wineEnv(): NodeJS.ProcessEnv {
+    return {
+          WINEPREFIX: winePrefix()
+        , WINEDLLOVERRIDES: 'mscoree,mshtml='
+        , WINEDEBUG: process.env.WINEDEBUG || '-all'
+    };
+}
+
+/**
+ * Terminates the wine session for tswow's dedicated prefix. This kills the
+ * (possibly frozen) Wow.exe and its wine host processes right away, where a
+ * plain kill of the launched `wine` process would leave them running.
+ */
+function killWineSession() {
+    try {
+        wsys.exec('wineserver -k', 'ignore', { env: { ...process.env, ...wineEnv() } });
+    } catch (err) {
+        // wineserver may already be gone; nothing to clean up.
+    }
+}
 
 export class Client {
     readonly dataset: Dataset
@@ -73,6 +109,15 @@ export class Client {
         let count = 0;
         if(processes !== undefined) {
             count = processes.length;
+            // On Linux the client runs under wine: the `wine` launcher we spawn
+            // is not the real Wow.exe (that lives under the shared wineserver),
+            // so killing the launcher alone leaves the game window frozen. Shut
+            // down the whole wine session for our dedicated prefix instead, which
+            // terminates Wow.exe and its wine host processes immediately without
+            // touching any other wine apps the user may be running.
+            if(!isWindows() && count > 0) {
+                killWineSession();
+            }
             await Promise.all(processes.map(x=>x.stop()));
         }
         delete processMap[this.dataset.fullName];
@@ -127,7 +172,17 @@ export class Client {
             if(isWindows()) {
                 process.start(this.path.wow_exe.get())
             } else {
-                process.start('wine',[this.path.wow_exe.get()])
+                // Run in the client directory so WoW resolves Data/ relative to
+                // the executable, and use the exe's own basename (case may differ
+                // from the lowercase "wow.exe" path on case-sensitive filesystems).
+                // A dedicated WINEPREFIX keeps the session isolated so it can be
+                // shut down cleanly on exit (see kill()).
+                process.startIn(
+                      this.dataset.config.client_path
+                    , 'wine'
+                    , [this.path.wow_exe.get()]
+                    , wineEnv()
+                )
             }
             processes.push(process);
             sleep(200)
@@ -136,11 +191,36 @@ export class Client {
 
     async startup(count: number = 1, ip: string = '127.0.0.1') {
         await this.kill();
+        this.ensureWowExe();
         await this.applyExePatches();
         this.installAddons();
         this.clearCache();
         this.writeRealmlist();
         this.start(count);
+    }
+
+    /**
+     * On case-sensitive filesystems (Linux/macOS) the client executable is
+     * usually shipped as "Wow.exe", but tswow expects a lowercase "wow.exe".
+     * If the lowercase file is missing, locate a case-insensitive match in the
+     * client directory and create a lowercase copy so the rest of the pipeline
+     * (patching + launching) works without the user renaming anything.
+     */
+    private ensureWowExe() {
+        if (isWindows()) { return; }
+        const exePath = this.path.wow_exe.get();
+        if (fs.existsSync(exePath)) { return; }
+        const clientDir = this.dataset.config.client_path;
+        let match: string | undefined;
+        try {
+            match = fs.readdirSync(clientDir).find(f => /^wow\.exe$/i.test(f));
+        } catch (err) {
+            return;
+        }
+        if (match && match !== 'wow.exe') {
+            fs.copyFileSync(mpath(clientDir, match), exePath);
+            term.log('client', `Created lowercase wow.exe from ${match} for case-sensitive filesystem`);
+        }
     }
 
     async exePatches() {
@@ -309,8 +389,15 @@ export class Client {
     static initialize() {
         term.debug('client', `Initializing client`)
         if(!process.argv.includes('noclient') && NodeConfig.AutoStartClient > 0) {
+            // Never let a client-startup failure take down the whole runtime
+            // (an unhandled rejection here escalates to uncaughtException, which
+            // kills the managed MySQL/server child processes). Log and continue.
             Identifier.getDataset(NodeConfig.DefaultDataset)
                 .client.startup(NodeConfig.AutoStartClient)
+                .catch(err => term.error(
+                      'client'
+                    , `Failed to auto-start client (server keeps running): ${err && err.message ? err.message : err}`
+                ))
         }
 
         StartCommand.addCommand(

--- a/tswow-scripts/runtime/Client.ts
+++ b/tswow-scripts/runtime/Client.ts
@@ -20,7 +20,7 @@ import { Args } from '../util/Args';
 import { ClientPatches, EXTENSION_DLL_PATCH_NAME } from '../util/ClientPatches';
 import { mpath, wfs } from '../util/FileSystem';
 import { WDirectory, WNode } from '../util/FileTree';
-import { ClientPath, findLocaleDir, ipaths } from '../util/Paths';
+import { ClientPath, ipaths } from '../util/Paths';
 import { isWindows } from '../util/Platform';
 import { Process } from '../util/Process';
 import { term } from '../util/Terminal';
@@ -47,16 +47,11 @@ export class Client {
             )
         }
 
-        const useLocale = this.dataset.config.ClientPatchUseLocale
-        let patchdir = mpath(this.dataset.config.client_path,'Data')
-        if(useLocale) {
-            patchdir = findLocaleDir(patchdir).get();
-        }
-
-        let patchFile = useLocale
-            ? `patch-${wfs.basename(patchdir)}-${this.dataset.config.ClientDevPatchLetter}.MPQ`
-            : `patch-${this.dataset.config.ClientDevPatchLetter}.MPQ`
-        let patchPath = mpath(patchdir,patchFile);
+        const patchPath = mpath(
+            this.dataset.config.client_path,
+            'Data',
+            `patch-${this.dataset.config.ClientDevPatchLetter.toUpperCase()}.MPQ`
+        );
 
         return ClientPath(
               this.dataset.config.client_path
@@ -65,10 +60,7 @@ export class Client {
     }
 
     patchDir() {
-        return (this.dataset.config.ClientPatchUseLocale
-            ? this.path.Data.locale()
-            : this.path.Data
-            ) as WDirectory
+        return this.path.Data as WDirectory
     }
 
     locale() {
@@ -248,11 +240,7 @@ export class Client {
     }
 
     patchPath(letter: string) {
-        return this.dataset.config.ClientPatchUseLocale
-            ? this.path.Data.locale()
-                .join(`patch-${this.locale()}-${letter.toUpperCase()}.MPQ`)
-            : this.path.Data
-                .join(`patch-${letter.toUpperCase()}.MPQ`)
+        return this.path.Data.join(`patch-${letter.toUpperCase()}.MPQ`)
     }
 
     verify() {
@@ -276,23 +264,25 @@ export class Client {
         return this.path.Cache.remove();
     }
 
-    freePatches() {
-        const ids: WNode[] = []
-
+    private _patchOrder() {
         const order: string[] = []
         for(let i=4;i<9;++i) order.push(`${i}`)
         for(let i='A'.charCodeAt(0);i<'Z'.charCodeAt(0);++i) {
             order.push(`${String.fromCharCode(i)}`)
         }
-
-        let start = order.indexOf(this.dataset.config.ClientDevPatchLetter.toUpperCase())
+        const start = order.indexOf(this.dataset.config.ClientDevPatchLetter.toUpperCase())
         if(start === -1) {
             throw new Error(
                   `Invalid patch letter: ${this.dataset.config.ClientDevPatchLetter}`
                 + ` (in dataset ${this.dataset.fullName})`
             )
         }
+        return { order, start };
+    }
 
+    freePatches() {
+        const ids: WNode[] = []
+        const { order, start } = this._patchOrder()
         for(let i=start;i<order.length;++i) {
             let path = this.patchPath(order[i]);
             if( !path.exists()
@@ -301,7 +291,18 @@ export class Client {
                 ids.push(path)
             }
         }
+        return ids;
+    }
 
+    freeNonLocalePatches() {
+        const ids: WNode[] = []
+        const { order, start } = this._patchOrder()
+        for(let i=start;i<order.length;++i) {
+            let path = this.path.Data.join(`patch-${order[i].toUpperCase()}.MPQ`)
+            if(!path.exists()) {
+                ids.push(path)
+            }
+        }
         return ids;
     }
 

--- a/tswow-scripts/runtime/Dataset.ts
+++ b/tswow-scripts/runtime/Dataset.ts
@@ -32,6 +32,10 @@ class DatasetManager {
 export class Dataset {
     private static managers: {[key: string]: DatasetManager} = {}
 
+    private hasContent(path: string) {
+        return wfs.exists(path) && wfs.readDir(path, true, 'files').length > 0
+    }
+
     private manager() {
         return Dataset.managers[this.fullName]
            || (Dataset.managers[this.fullName] = new DatasetManager(this.fullName))
@@ -104,23 +108,30 @@ export class Dataset {
     async setupClientData() {
         term.debug(this.logName(), `Setting up client data`)
         let anyChange: boolean = false;
-        if(!this.path.luaxml_source.exists()) {
+        const hasLuaxmlBase = wfs.exists(
+            this.path.luaxml_source
+                .join('Interface/GlueXML/CharacterCreate.xml')
+                .get()
+        )
+
+        if(!this.hasContent(this.path.luaxml_source.get()) || !hasLuaxmlBase) {
             MapData.luaxml(this);
             anyChange = true;
         }
 
         this.path.luaxml_source.copyOnNoTarget(this.path.luaxml)
 
-        if(!this.path.dbc_source.exists()) {
+        if(!this.hasContent(this.path.dbc_source.get())) {
             MapData.dbc(this);
+            anyChange = true;
         }
 
-        if(!this.path.maps.exists()) {
+        if(!this.hasContent(this.path.maps.get())) {
             MapData.map(this);
             anyChange = true;
         }
 
-        if(!this.path.vmaps.exists()) {
+        if(!this.hasContent(this.path.vmaps.get())) {
             MapData.vmap_extract(this);
             MapData.vmap_assemble(this)
             anyChange = true;
@@ -156,6 +167,9 @@ export class Dataset {
         switch(this.config.EmulatorCore) {
             case 'trinitycore':
                 await mysql.applySQLFiles(db,'world');
+                if(db === this.worldDest) {
+                    await mysql.selfHealWorldDest(this.worldSource, this.worldDest)
+                }
                 break;
         }
     }
@@ -216,7 +230,7 @@ export class Dataset {
             })
         })
         this.modules().filter(x=>x.path.assets.exists()).forEach(x=>{
-            let patches = this.client.freePatches()
+            let patches = this.client.freeNonLocalePatches()
             if(patches.length === 0) {
                 throw new Error(`Client has no more free patches to symlink: ${this.client.path}`)
             }

--- a/tswow-scripts/runtime/Dataset.ts
+++ b/tswow-scripts/runtime/Dataset.ts
@@ -2,6 +2,7 @@ import { patchTCConfig } from "../util/ConfigFile";
 import { DatasetConfig, GAME_BUILD_FIELD } from "../util/DatasetConfig";
 import { wfs } from "../util/FileSystem";
 import { ipaths } from "../util/Paths";
+import { isWindows } from "../util/Platform";
 import { term } from "../util/Terminal";
 import { termCustom } from "../util/TerminalCategories";
 import { Client } from "./Client";
@@ -12,6 +13,8 @@ import { Module, ModuleEndpoint } from "./Modules";
 import { Connection, mysql } from "./MySQL";
 import { NodeConfig } from "./NodeConfig";
 import { Realm } from "./Realm";
+import * as fs from "fs";
+import * as path from "path";
 
 class DatasetManager {
     worldSource: Connection;
@@ -107,39 +110,91 @@ export class Dataset {
 
     async setupClientData() {
         term.debug(this.logName(), `Setting up client data`)
-        let anyChange: boolean = false;
-        const hasLuaxmlBase = wfs.exists(
-            this.path.luaxml_source
-                .join('Interface/GlueXML/CharacterCreate.xml')
-                .get()
-        )
+        // Temporary uppercase .MPQ symlinks for the extraction tools; removed in
+        // the finally block so the game client never sees duplicate archives.
+        const tempMpqLinks = this.normalizeClientMpqs();
+        try {
+            let anyChange: boolean = false;
+            const hasLuaxmlBase = wfs.exists(
+                this.path.luaxml_source
+                    .join('Interface/GlueXML/CharacterCreate.xml')
+                    .get()
+            )
 
-        if(!this.hasContent(this.path.luaxml_source.get()) || !hasLuaxmlBase) {
-            MapData.luaxml(this);
-            anyChange = true;
+            if(!this.hasContent(this.path.luaxml_source.get()) || !hasLuaxmlBase) {
+                MapData.luaxml(this);
+                anyChange = true;
+            }
+
+            this.path.luaxml_source.copyOnNoTarget(this.path.luaxml)
+
+            if(!this.hasContent(this.path.dbc_source.get())) {
+                MapData.dbc(this);
+                anyChange = true;
+            }
+
+            if(!this.hasContent(this.path.maps.get())) {
+                MapData.map(this);
+                anyChange = true;
+            }
+
+            if(!this.hasContent(this.path.vmaps.get())) {
+                MapData.vmap_extract(this);
+                MapData.vmap_assemble(this)
+                anyChange = true;
+            }
+
+            if(anyChange) {
+                term.success(this.logName(),'Finished installing server data');
+            }
+        } finally {
+            for(const link of tempMpqLinks) {
+                try { fs.unlinkSync(link); } catch(err) { /* ignore */ }
+            }
         }
+    }
 
-        this.path.luaxml_source.copyOnNoTarget(this.path.luaxml)
-
-        if(!this.hasContent(this.path.dbc_source.get())) {
-            MapData.dbc(this);
-            anyChange = true;
+    /**
+     * Case-sensitive filesystems: extraction tools (luaxmlreader, mapextractor)
+     * expect uppercase ".MPQ" archives, but clients often ship lowercase ".mpq".
+     * Symlink the missing uppercase names and return them so the caller can
+     * remove them after extraction (leaving duplicates crashes the game client).
+     */
+    private normalizeClientMpqs(): string[] {
+        const created: string[] = [];
+        if(isWindows()) { return created; }
+        let dataDir: string;
+        let localeDir: string;
+        try {
+            dataDir = this.client.path.Data.get();
+            localeDir = this.client.path.Data.locale().get();
+        } catch(err) {
+            return created;
         }
-
-        if(!this.hasContent(this.path.maps.get())) {
-            MapData.map(this);
-            anyChange = true;
+        for(const dir of [dataDir, localeDir]) {
+            let entries: string[];
+            try {
+                entries = fs.readdirSync(dir);
+            } catch(err) {
+                continue;
+            }
+            for(const name of entries) {
+                const match = name.match(/^(.*)\.mpq$/);
+                if(!match) { continue; }
+                const upper = `${match[1]}.MPQ`;
+                if(name === upper) { continue; }
+                const upperPath = path.join(dir, upper);
+                if(fs.existsSync(upperPath)) { continue; }
+                try {
+                    fs.symlinkSync(name, upperPath);
+                    created.push(upperPath);
+                    term.log(this.logName(), `Linked ${upper} -> ${name} (case-sensitive filesystem)`);
+                } catch(err) {
+                    // ignore; extraction will report a clearer error if truly missing
+                }
+            }
         }
-
-        if(!this.hasContent(this.path.vmaps.get())) {
-            MapData.vmap_extract(this);
-            MapData.vmap_assemble(this)
-            anyChange = true;
-        }
-
-        if(anyChange) {
-            term.success(this.logName(),'Finished installing server data');
-        }
+        return created;
     }
 
     protected async setupDatabase(db: Connection, force: boolean) {

--- a/tswow-scripts/runtime/MapData.ts
+++ b/tswow-scripts/runtime/MapData.ts
@@ -32,6 +32,28 @@ import { NodeConfig } from './NodeConfig';
  * runs `mapextractor`, `vmap4extractor`, `vmap4assembler` etc. and installs the results to TrinityCore.
  */
 export namespace MapData {
+  function ensureLegacyDevPatch(dataset: Dataset) {
+    const letter = dataset.config.ClientDevPatchLetter.toUpperCase();
+    const dataDir = dataset.client.path.Data;
+    const rootPatch = dataDir.join(`patch-${letter}.MPQ`);
+    if (rootPatch.exists()) {
+      return;
+    }
+
+    const localeDir = dataDir.locale();
+    if (!localeDir.exists()) {
+      return;
+    }
+
+    const localePatch = localeDir.join(`patch-${localeDir.basename()}-${letter}.MPQ`);
+    if (!localePatch.exists()) {
+      return;
+    }
+
+    term.debug('misc', `Creating compatibility dev patch ${rootPatch.abs()} from ${localePatch.abs()}`);
+    wfs.copy(localePatch.get(), rootPatch.get());
+  }
+
     export function dbc (
         dataset: Dataset
       , type: BuildType = NodeConfig.DefaultBuildType
@@ -121,6 +143,7 @@ export namespace MapData {
 
     export function luaxml(dataset: Dataset) {
         term.debug('misc', `Building luaxml from ${dataset.client.path.abs()}`)
+        ensureLegacyDevPatch(dataset);
         wsys.exec(
               `"${ipaths.bin.mpqbuilder.luaxml_exe.get()}"`
             + ` ${dataset.path.luaxml_source.abs()}`

--- a/tswow-scripts/runtime/MySQL.ts
+++ b/tswow-scripts/runtime/MySQL.ts
@@ -251,9 +251,46 @@ export namespace mysql {
         )
     }
 
+    let cachedIsMariaDB: boolean | undefined = undefined;
+
+    /**
+     * Whether the local database server binary is MariaDB (as opposed to MySQL).
+     * MariaDB requires different initialization and startup flags than MySQL.
+     */
+    function isMariaDB(): boolean {
+        if (cachedIsMariaDB === undefined) {
+            try {
+                const version = wsys.exec(`"${mysqldExe()}" --version`, 'pipe');
+                cachedIsMariaDB = /mariadb/i.test(version);
+            } catch (error) {
+                cachedIsMariaDB = false;
+            }
+        }
+        return cachedIsMariaDB;
+    }
+
+    // Database binaries: bundled .exe on Windows, resolved system binary elsewhere.
+    function mysqldExe(): string {
+        return isWindows() ? ipaths.bin.mysql.mysqld_exe.get() : wsys.resolveExe(['mariadbd', 'mysqld']);
+    }
+    function mysqlClientExe(): string {
+        return isWindows() ? ipaths.bin.mysql.mysql_exe.get() : wsys.resolveExe(['mariadb', 'mysql']);
+    }
+    function mysqldumpExe(): string {
+        return isWindows() ? ipaths.bin.mysql.mysqldump_exe.get() : wsys.resolveExe(['mariadb-dump', 'mysqldump']);
+    }
+
+    // Socket + pid file for the tswow-managed database process (Linux/macOS).
+    function socketPath(): string {
+        return wfs.absPath(ipaths.coredata.join('tswow-db.sock').get());
+    }
+    function pidPath(): string {
+        return wfs.absPath(ipaths.coredata.join('tswow-db.pid').get());
+    }
+
     export function dump(connection: Connection, outputFile: string) {
         wsys.exec(
-            `"${ipaths.bin.mysql.mysqldump_exe.get()}"`
+            `"${mysqldumpExe()}"`
             + ` --port ${connection.cfg.port}`
             + ` --host ${connection.cfg.host}`
             + ` -u root ${connection.cfg.database}`
@@ -266,14 +303,34 @@ export namespace mysql {
         if(!ipaths.coredata.database.exists()) {
             term.log('mysql',"No mysql database found, creating it...");
             try {
-                wsys.exec(
-                    `${ipaths.bin.mysql.mysqld_exe.get()}`
-                    + ` --initialize`
-                    + ` --log_syslog=0`
-                    + ` --datadir=${ipaths.coredata.database.abs()}`);
+                if (isWindows()) {
+                    wsys.exec(
+                        `${mysqldExe()}`
+                        + ` --initialize`
+                        + ` --log_syslog=0`
+                        + ` --datadir=${ipaths.coredata.database.abs()}`);
+                } else if (isMariaDB()) {
+                    // MariaDB uses mariadb-install-db instead of `--initialize`.
+                    const installDb = wsys.resolveExe(['mariadb-install-db', 'mysql_install_db']);
+                    wsys.exec(
+                        `"${installDb}"`
+                        + ` --datadir="${wfs.absPath(ipaths.coredata.database.get())}"`
+                        + ` --auth-root-authentication-method=normal`
+                        + ` --skip-test-db`);
+                } else {
+                    // System MySQL on Linux
+                    wsys.exec(
+                        `"${mysqldExe()}"`
+                        + ` --initialize-insecure`
+                        + ` --datadir="${wfs.absPath(ipaths.coredata.database.get())}"`);
+                }
             } catch(error) {
-                term.error('mysql',`Failed to start MySQL: ${error.message}`)
-                term.error('mysql',`Make sure you installed all vcredist versions needed`)
+                term.error('mysql',`Failed to initialize database: ${error.message}`)
+                if (isWindows()) {
+                    term.error('mysql',`Make sure you installed all vcredist versions needed`)
+                } else {
+                    term.error('mysql',`Make sure mariadb/mysql server is installed (e.g. 'pacman -S mariadb' or 'apt install mariadb-server')`)
+                }
                 term.error('mysql',`See wiki for installation instructions: https://tswow.github.io/tswow-wiki/`)
                 process.exit(-1);
             }
@@ -311,16 +368,24 @@ export namespace mysql {
 
         const [user,pass] = Object.entries(users).find(()=>true);
 
+        // Grant the user on both localhost (unix socket) and 127.0.0.1 (TCP), since
+        // the emulator connects via TCP while the init-file runs over the socket.
         wfs.write(ipaths.bin.mysql_startup.get(),
               `CREATE USER IF NOT EXISTS`
             + ` '${user}'@'localhost'`
             + ` IDENTIFIED BY '${pass}';`
             + `\nGRANT ALL ON *.* TO '${user}'@'localhost';`
-            + `\nALTER USER '${user}'@'localhost' IDENTIFIED BY '${pass}';`);
-            + "`\nSET @@GLOBAL.wait_timeout=2147483"
+            + `\nALTER USER '${user}'@'localhost' IDENTIFIED BY '${pass}';`
+            + `\nCREATE USER IF NOT EXISTS`
+            + ` '${user}'@'127.0.0.1'`
+            + ` IDENTIFIED BY '${pass}';`
+            + `\nGRANT ALL ON *.* TO '${user}'@'127.0.0.1';`
+            + `\nALTER USER '${user}'@'127.0.0.1' IDENTIFIED BY '${pass}';`
+            + `\nFLUSH PRIVILEGES;`);
         await disconnect();
-        mysqlprocess.start(ipaths.bin.mysql.mysqld_exe.get(),
-            [
+
+        const startArgs = isWindows()
+            ? [
                 `--port=${NodeConfig.DatabaseHostedPort}`,
                 '--log_syslog=0',
                 '--console',
@@ -328,10 +393,25 @@ export namespace mysql {
                 '--wait_timeout=2147483',
                 `--init-file=${wfs.absPath(ipaths.bin.mysql_startup.get())}`,
                 `--datadir=${wfs.absPath(ipaths.coredata.database.get())}`
-            ]);
+            ]
+            : [
+                `--port=${NodeConfig.DatabaseHostedPort}`,
+                `--socket=${socketPath()}`,
+                `--pid-file=${pidPath()}`,
+                '--wait-timeout=2147483',
+                `--init-file=${wfs.absPath(ipaths.bin.mysql_startup.get())}`,
+                `--datadir=${wfs.absPath(ipaths.coredata.database.get())}`
+            ];
+
+        mysqlprocess.start(mysqldExe(), startArgs);
         mysqlprocess.showOutput(process.argv.includes('logmysql'));
+        // MariaDB/MySQL on Linux log 'ready for connections' once the init-file has
+        // been executed, while Windows MySQL logs 'Execution of init_file ended.'.
+        const readyMessage = isWindows()
+            ? 'Execution of init_file*ended.'
+            : 'ready for connections'
         let val = await Promise.race([
-            mysqlprocess.waitForMessage('Execution of init_file*ended.', true),
+            mysqlprocess.waitForMessage(readyMessage, true),
             mysqlprocess.waitForMessage('Can\'t start server', true),
         ]);
         if(val.includes('Can\'t start server')) {
@@ -353,10 +433,25 @@ export namespace mysql {
 
     /**
      * Returns whether this instance of TSWoW should manage its own MySQL process.
+     *
+     * On Windows, TSWoW bundles its own MySQL. On Linux/macOS it uses the system
+     * mariadbd/mysqld binary but still manages the process/data directory itself
+     * so that `npm start` works out of the box without a preconfigured server.
      */
     export function hasOwnProcess() {
-        return isWindows()
-            && NodeConfig.DatabaseHostedPort !== 0;
+        return NodeConfig.DatabaseHostedPort !== 0;
+    }
+
+    /**
+     * Absolute path to the MySQL/MariaDB client executable used by the emulator
+     * (worldserver) for e.g. running SQL updates. Resolves the bundled binary on
+     * Windows and the system mariadb/mysql client on Linux/macOS.
+     */
+    export function clientExecutable() {
+        if (isWindows()) {
+            return ipaths.bin.mysql.mysql_exe.abs().get();
+        }
+        return mysqlClientExe();
     }
 
     /**
@@ -419,7 +514,7 @@ export namespace mysql {
         await con.clean();
 
         const mysqlCommand = mysql.hasOwnProcess() ?
-            `"${ipaths.bin.mysql.mysql_exe.get()}"` :
+            `"${mysqlClientExe()}"` :
                 NodeConfig.MySQLExecutable != '' ?
             `"${NodeConfig.MySQLExecutable}"`:
                 `mysql`;

--- a/tswow-scripts/runtime/MySQL.ts
+++ b/tswow-scripts/runtime/MySQL.ts
@@ -15,6 +15,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 import * as mysql_lib from 'mysql2';
+import * as child_process from 'child_process';
 import path from 'path';
 import { start } from 'repl';
 import { commands } from '../util/Commands';
@@ -190,6 +191,66 @@ export class Connection {
 export namespace mysql {
     const mysqlprocess: Process = new Process('mysql');
 
+    function id(name: string) {
+        return `\`${name.split('`').join('``')}\``;
+    }
+
+    export async function ensureUpdatesTable(con: Connection) {
+        await con.query(
+              `CREATE TABLE IF NOT EXISTS ${id('updates')} (`
+            + `${id('name')} VARCHAR(200) NOT NULL,`
+            + `${id('hash')} VARCHAR(40) NOT NULL DEFAULT '',`
+            + `${id('state')} VARCHAR(20) NOT NULL DEFAULT 'RELEASED',`
+            + `${id('installedOn')} TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,`
+            + `${id('speed')} INT NOT NULL DEFAULT 0,`
+            + `PRIMARY KEY (${id('name')})`
+            + `);`
+        )
+    }
+
+    export async function selfHealWorldDest(source: Connection, dest: Connection) {
+        const missingTables = await source.query(
+              `SELECT s.table_name FROM information_schema.tables s `
+            + `LEFT JOIN information_schema.tables d `
+            + `ON d.table_schema='${dest.name()}' AND d.table_name=s.table_name `
+            + `WHERE s.table_schema='${source.name()}' `
+            + `AND s.table_type='BASE TABLE' `
+            + `AND d.table_name IS NULL;`
+        )
+
+        for (const row of missingTables as { table_name: string }[]) {
+            const table = row.table_name;
+            await dest.query(
+                  `CREATE TABLE IF NOT EXISTS ${id(dest.name())}.${id(table)} `
+                + `LIKE ${id(source.name())}.${id(table)};`
+            )
+        }
+
+        const hasTrinityString = await dest.query(
+              `SELECT COUNT(*) AS c FROM information_schema.tables `
+            + `WHERE table_schema='${dest.name()}' AND table_name='trinity_string';`
+        ) as { c: number }[];
+
+        if ((hasTrinityString[0]?.c || 0) === 0) {
+            return;
+        }
+
+        const destCount = await dest.query(`SELECT COUNT(*) AS c FROM ${id('trinity_string')};`) as { c: number }[];
+        if ((destCount[0]?.c || 0) > 0) {
+            return;
+        }
+
+        const sourceCount = await source.query(`SELECT COUNT(*) AS c FROM ${id('trinity_string')};`) as { c: number }[];
+        if ((sourceCount[0]?.c || 0) === 0) {
+            return;
+        }
+
+        await dest.query(
+              `TRUNCATE TABLE ${id('trinity_string')};`
+            + `INSERT INTO ${id('trinity_string')} SELECT * FROM ${id(source.name())}.${id('trinity_string')};`
+        )
+    }
+
     export function dump(connection: Connection, outputFile: string) {
         wsys.exec(
             `"${ipaths.bin.mysql.mysqldump_exe.get()}"`
@@ -363,16 +424,20 @@ export namespace mysql {
             `"${NodeConfig.MySQLExecutable}"`:
                 `mysql`;
 
-        await wsys.execAsync(
-              `${mysqlCommand}`
-            + ` -u ${con.cfg.user}`
-            + ` --default-character-set=utf8`
-            + (con.cfg.password.length > 0
-                ? ` -p${con.cfg.password}`
-                : '')
-            + ` --port ${con.cfg.port}`
-            + ` --host ${con.cfg.host}`
-            + ` ${con.name()} < ${sqlFilePath}`);
+        await new Promise<void>((res, rej) => {
+            child_process.exec(
+                  `${mysqlCommand}`
+                + ` -u ${con.cfg.user}`
+                + ` --default-character-set=utf8`
+                + (con.cfg.password.length > 0
+                    ? ` -p${con.cfg.password}`
+                    : '')
+                + ` --port ${con.cfg.port}`
+                + ` --host ${con.cfg.host}`
+                + ` ${con.name()} < ${sqlFilePath}`
+                , { maxBuffer: 512 * 1024 * 1024 }
+                , (err) => err ? rej(err) : res());
+        });
         term.success('mysql',`Rebuilt database ${con.name()}`);
     }
 
@@ -407,6 +472,7 @@ export namespace mysql {
           cons: Connection
         , type: 'world'|'auth'|'characters'
     ) {
+        await ensureUpdatesTable(cons)
         let total = await makeUpdate(cons, ipaths.bin.sql.updates.type.pick(type)._335.toDirectory())
         total += await makeUpdate(cons, ipaths.bin.sql.custom.type.pick(type).toDirectory())
         if(total > 0) {

--- a/tswow-scripts/runtime/Realm.ts
+++ b/tswow-scripts/runtime/Realm.ts
@@ -277,7 +277,10 @@ export class Realm {
         this.lastBuildType = type;
         await this.connect();
         await this.config.Dataset.setupDatabases('BOTH',false);
-        await this.config.Dataset.setupClientData()
+        const isServerOnlyStart = process.argv.includes('server-mode') || process.argv.includes('noclient')
+        if(!isServerOnlyStart) {
+            await this.config.Dataset.setupClientData()
+        }
         this.config.Dataset.writeModulesTxt()
 
         // Generate .conf files

--- a/tswow-scripts/runtime/Realm.ts
+++ b/tswow-scripts/runtime/Realm.ts
@@ -279,7 +279,17 @@ export class Realm {
         await this.config.Dataset.setupDatabases('BOTH',false);
         const isServerOnlyStart = process.argv.includes('server-mode') || process.argv.includes('noclient')
         if(!isServerOnlyStart) {
-            await this.config.Dataset.setupClientData()
+            // Client data (dbc/maps/vmaps) is extracted here. If extraction fails
+            // or is incomplete, still start the worldserver so the realm comes
+            // online (it logs missing-map warnings but login/characters work).
+            try {
+                await this.config.Dataset.setupClientData()
+            } catch(err) {
+                term.error(
+                      this.logName()
+                    , `Client data setup failed (starting worldserver anyway): ${err && (err as any).message ? (err as any).message : err}`
+                )
+            }
         }
         this.config.Dataset.writeModulesTxt()
 
@@ -317,7 +327,7 @@ export class Realm {
               this.path.worldserver_conf.get()
             , 'MySQLExecutable'
             , NodeConfig.MySQLExecutable.length === 0
-                ? ipaths.bin.mysql.mysql_exe.abs().get()
+                ? mysql.clientExecutable()
                 : '"NodeConfig.MySQLExecutable"'
         )
 

--- a/tswow-scripts/test/FileSystem/AsyncFileSystemTests.ts
+++ b/tswow-scripts/test/FileSystem/AsyncFileSystemTests.ts
@@ -29,7 +29,7 @@ describe('FileSystem', function () {
 
     this.afterEach(function() {
         sleep(5);
-        fs.rmSync(tempdir, {recursive: true});
+        fs.rmSync(tempdir, {recursive: true, force: true});
     });
 
     describe('wfsa', function() {

--- a/tswow-scripts/test/FileSystem/SyncFileSystemTests.ts
+++ b/tswow-scripts/test/FileSystem/SyncFileSystemTests.ts
@@ -29,7 +29,7 @@ describe('FileSystem', function () {
 
     this.afterEach(function() {
         sleep(5);
-        fs.rmSync(tempdir, {recursive: true});
+        fs.rmSync(tempdir, {recursive: true, force: true});
     });
 
     describe('wfs', function() {

--- a/tswow-scripts/test/wotlkdata/LUAXMLTest.ts
+++ b/tswow-scripts/test/wotlkdata/LUAXMLTest.ts
@@ -47,7 +47,7 @@ const TEXT_FILE_LENGTH = 382;
 function clear() {
     _clearLUAXML();
     if (fs.existsSync('./tmp')) {
-        fs.rmSync('./tmp', {recursive: true});
+        fs.rmSync('./tmp', {recursive: true, force: true});
     }
 }
 

--- a/tswow-scripts/util/7zip.ts
+++ b/tswow-scripts/util/7zip.ts
@@ -19,16 +19,25 @@ import { wsys } from './System';
 import { term } from './Terminal';
 
 export namespace SevenZip {
+    // The bundled 7za is Windows-only; on Linux/macOS use the system 7-Zip.
+    function systemSevenZip(): string {
+        return wsys.resolveExe(['7za', '7z', '7zr']);
+    }
+
     export function extract(sevenZipPath: string, archive: string, out: string) {
         term.debug('misc', `Extracting ${archive} to ${out}`)
         if(isWindows()) {
             wsys.exec(`"${sevenZipPath}" e -o${out} ${archive}`);
         } else {
-            wsys.execIn(out,`7z x "${archive}"`,'inherit')
+            wsys.exec(`"${systemSevenZip()}" e -o"${out}" "${archive}" -y`,'inherit')
         }
     }
 
     export function makeArchive(sevenZipPath: string, zipPath: string, directoryIn: string[]) {
-        wsys.exec(`"${sevenZipPath}" a ${zipPath} ${directoryIn.join(' ')} -mx=9 -mmt=on -sfx7z.sfx`,'inherit');
+        if(isWindows()) {
+            wsys.exec(`"${sevenZipPath}" a ${zipPath} ${directoryIn.join(' ')} -mx=9 -mmt=on -sfx7z.sfx`,'inherit');
+        } else {
+            wsys.exec(`"${systemSevenZip()}" a ${zipPath} ${directoryIn.join(' ')} -mx=9 -mmt=on`,'inherit');
+        }
     }
 }

--- a/tswow-scripts/util/CompileTS.ts
+++ b/tswow-scripts/util/CompileTS.ts
@@ -68,5 +68,5 @@ export function clearTscWatchers() {
 }
 
 export function compileTsc(dir: string) {
-    wsys.execIn(dir,'tsc','inherit');
+    wsys.execIn(dir,'npx tsc','inherit');
 }

--- a/tswow-scripts/util/FileSystem.ts
+++ b/tswow-scripts/util/FileSystem.ts
@@ -191,7 +191,7 @@ export namespace wfsa {
                     }
                 });
             } else if (await wfsa.isDirectory(fpath)) {
-                fs.rm(resfp(fpath), {recursive: true}, (err) => {
+                fs.rm(resfp(fpath), {recursive: true, force: true}, (err) => {
                     if (err) {
                         rej(err);
                     } else {
@@ -354,7 +354,7 @@ export namespace wfs {
         if (fs.lstatSync(resfp(removedPath)).isFile()) {
             fs.unlinkSync(resfp(removedPath));
         } else {
-            fs.rmSync(resfp(removedPath), {recursive: true});
+            fs.rmSync(resfp(removedPath), {recursive: true, force: true});
         }
     }
 

--- a/tswow-scripts/util/NodeConfig.ts
+++ b/tswow-scripts/util/NodeConfig.ts
@@ -132,7 +132,7 @@ export class NodeConfigClass extends ConfigFile {
     @Property({
         name: 'Database.WorldSource'
       , description: 'This is the database used to read datascripts.'
-      , examples: [["localhost;3306;tswow;password",'']]
+      , examples: [["127.0.0.1;3306;tswow;password",'']]
     })
     DatabaseWorldSource!: string
 
@@ -140,21 +140,21 @@ export class NodeConfigClass extends ConfigFile {
         name: 'Database.WorldDest'
       , description:  'This is the database used by the worldserver. '
                     + 'Datascripts writes to this database.'
-      , examples: [["localhost;3306;tswow;password",'']]
+      , examples: [["127.0.0.1;3306;tswow;password",'']]
     })
     DatabaseWorldDest!: string
 
     @Property({
         name: 'Database.Auth'
       , description:  'This is the database used by the auth server. '
-      , examples: [["localhost;3306;tswow;password",'']]
+      , examples: [["127.0.0.1;3306;tswow;password",'']]
     })
     DatabaseAuth!: string
 
     @Property({
         name: 'Database.Characters'
       , description:  'This is the database storing dynamic game data, such as characters. '
-      , examples: [["localhost;3306;tswow;password",'']]
+      , examples: [["127.0.0.1;3306;tswow;password",'']]
     })
     DatabaseCharacters!: string
 

--- a/tswow-scripts/util/Paths.ts
+++ b/tswow-scripts/util/Paths.ts
@@ -28,11 +28,17 @@ export const DATASET_CLIENT_PATCH_LETTER = 'Client.Patch.Letter'
 
 function currentCommitShort()
 {
-    return child_process
-        .execSync('git rev-parse --short HEAD')
-        .toString('utf-8')
-        .trimRight()
-        .trimLeft()
+    // Best-effort: builds from a ZIP/tarball download (no .git) or without git
+    // installed should still work. Only affects the release-installer filename.
+    try {
+        return child_process
+            .execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+            .toString('utf-8')
+            .trimRight()
+            .trimLeft()
+    } catch (err) {
+        return 'unknown'
+    }
 }
 
 export function tdbFilename() {

--- a/tswow-scripts/util/Process.ts
+++ b/tswow-scripts/util/Process.ts
@@ -55,7 +55,7 @@ export class Process {
     private _onFail: ((err: Error)=>void)|undefined = undefined;
     private _isStopping: boolean = false;
     private _autoRestart: boolean = false;
-    private _lastStart?: {directory : FilePath, program: string, args: string[]} = undefined
+    private _lastStart?: {directory : FilePath, program: string, args: string[], env?: NodeJS.ProcessEnv} = undefined
 
     private _lineBuffers = {
         stderr: {value: '', idx: 0},
@@ -199,14 +199,15 @@ export class Process {
           directory: FilePath
         , program: string
         , args: string[] = []
+        , env?: NodeJS.ProcessEnv
     ) {
         await this.stop();
-        this._lastStart = {directory,program,args};
+        this._lastStart = {directory,program,args,env};
         this._isStopping = false;
         const proc = child_process.spawn(
               program
             , args
-            , {stdio:'pipe',cwd:resfp(directory)}
+            , {stdio:'pipe',cwd:resfp(directory),env: env ? {...process.env, ...env} : process.env}
         )
         this._process = processes[proc.pid] = proc;
         this._process.stdout.on('data', (data) => {
@@ -281,7 +282,7 @@ export class Process {
     private postFail() {
         if(this._autoRestart && this._lastStart) {
             term.log('process',`Automatically restarting ${this._lastStart.program}`)
-            this.startIn(this._lastStart.directory, this._lastStart.program, this._lastStart.args);
+            this.startIn(this._lastStart.directory, this._lastStart.program, this._lastStart.args, this._lastStart.env);
         }
     }
 

--- a/tswow-scripts/util/System.ts
+++ b/tswow-scripts/util/System.ts
@@ -138,6 +138,33 @@ export namespace wsys {
     }
 
     /**
+     * Returns whether a command is available on the system PATH.
+     */
+    export function hasCommand(command: string): boolean {
+        try {
+            child_process.execSync(`command -v ${command}`, { stdio: 'ignore' });
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    /**
+     * Resolves the first available executable from a list of candidate command
+     * names, returning its absolute path. Falls back to the last candidate as a
+     * bare command name if none are found on the PATH.
+     */
+    export function resolveExe(candidates: string[]): string {
+        for (const candidate of candidates) {
+            try {
+                const found = exec(`command -v ${candidate}`, 'pipe').trim();
+                if (found.length > 0) { return found; }
+            } catch (error) { /* try next candidate */ }
+        }
+        return candidates[candidates.length - 1];
+    }
+
+    /**
      * Sleeps for a specified time
      * @param timeout Milliseconds to sleep for.
      * @returns Promise that resolves after `timeout` milliseconds.

--- a/tswow-scripts/util/System.ts
+++ b/tswow-scripts/util/System.ts
@@ -84,6 +84,7 @@ export namespace wsys {
     /**
      * Executes a child process asynchronously
      * @param program Command to execute
+     * @param cwd Working directory to execute in
      * @throws if the child process exits with an error
      * @returns Promise when the child process exits
      */


### PR DESCRIPTION
Bit of an update on this one. I kept going after the build stuff and ended up getting a full server + client actually running on a clean Arch install, so I fixed the runtime problems I hit along the way too. It's bigger than it started. If that's annoying to review I can split it back out, just let me know.

Point of it is that on Linux you can now clone, run the build once, and come back to a running server and the wine client without hand-following the TrinityCore wiki. Windows already does that, Linux didn't really.

Build stuff (what this PR originally was):

- Builds under gcc 16 / cmake 4 / boost 1.9x now. Compiler comes from TSWOW_CC/TSWOW_CXX with gcc as the default, parallel make, cmake policy minimum bumped for the old vendored deps, and the little boost_system fallback for distros that dropped the per-component config.
- Added a dependency check at the top of build.js. It looks for the toolchain/cmake/boost/openssl/mariadb/7zip etc before doing anything and if something's missing it just prints the exact pacman/apt/dnf line for you instead of blowing up with some node-gyp mess 20 minutes in. Doesn't install anything itself unless you pass --install-deps (needs root). Had to put it in build.js because it runs before the first npm install, and that already needs a compiler for the native modules.
- If the TrinityCore submodule isn't there it tells you to run git submodule update --init --recursive instead of a cryptic cmake error.
- Uses the system 7-Zip to unpack the world DB. The bundled 7za is windows only and the old linux path called "p7zip" which isn't actually a command on arch.
- Doesn't choke when there's no .git (zip downloads).
- Swapped fs.rmdir({recursive}) for fs.rm. Node 26 removed the old one and it was silently hanging the build during the header copy, took me a while to find that.

Runtime stuff (new):

- Manages a local MariaDB itself, same as windows does with its bundled mysql - inits the datadir, starts it on a private socket, makes the tswow user. Before this linux just assumed you already had a mysql server set up and running.
- DB host defaults to 127.0.0.1 instead of localhost. With localhost the trinitycore mysql client goes looking for a unix socket at the default path and never finds ours, so auth/worldserver couldn't open their pools. This one confused me for a while.
- Case sensitivity for the client - finds Wow.exe whatever the case, and symlinks the uppercase .MPQ names the extractors want temporarily then removes them so the game client doesn't trip over duplicate archives.
- Skips a missing optional patch mpq during luaxml extraction instead of aborting.
- Client problems don't kill the server anymore. A bad client start or an extraction error used to become an unhandled rejection that killed the managed mariadb and hung the whole thing.
- Wine client shutdown. Runs the client in its own WINEPREFIX so stopping/restarting it can kill just that wine session cleanly instead of leaving a frozen Wow.exe and its wine helpers lying around. Won't touch other wine apps you've got open.

Windows paths are untouched, it's all behind isWindows() or in the linux-only branches.

On testing - I didn't want to just eyeball it so I ran it in throwaway qemu Arch VMs from a plain cloud image with nothing installed. Bare box with only node/npm/git, ran the build with --install-deps and it pulled the missing packages, compiled trinitycore all the way under gcc, downloaded and extracted the world db, built the helper tools and finished with "Installation successful". Then the runtime brought itself up - mariadb self-initialised, dbs created and migrated, authserver up on 3724 over 127.0.0.1, worldserver built and connected. On the VM with no client it stopped at "no maps" which is correct, and on one where I copied a real 3.3.5a client in the worldserver loaded 135 maps and hit "worldserver-daemon ready". Also ran the whole thing on my own machine and logged into the world, which is how I found the client-side runtime bugs above.

The matching TrinityCore submodule changes (boost::process moving to a v1 namespace in 1.91, the asio deadline_timer stuff, a couple filesystem renames) are over in tswow/TrinityCore#52 so they can be looked at separately instead of buried in here.

Couple notes - the one behaviour change for existing linux users is the default compiler going clang -> gcc, which was already in the first version of this. TSWOW_CC/TSWOW_CXX still override. And I've only actually tested on Arch; I tried to keep the preflight distro-agnostic (it covers apt/dnf/zypper too) but I can't personally vouch for ubuntu/fedora being clean.

Fine with splitting it up or dropping bits you don't want, whatever's easiest to get in.
